### PR TITLE
feat: Phase 2 — Payload CMS v3 schema, collections, globals, and deployment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ Thumbs.db
 pnpm-debug.log*
 npm-debug.log*
 
+# ─── CMS (Payload + Next.js) ──────────────────────────────────────────────────
+/cms/node_modules/
+/cms/.next/
+/cms/media/
+/cms/.env
+/cms/payload-types.ts
+
 # ─── Claude Code ──────────────────────────────────────────────────────────────
 .claude/
 /agents/docs/local/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.1.0](https://github.com/hari-houdini/me-portfolio/compare/v1.0.0...v1.1.0) (2026-03-25)
+
+
+### Bug Fixes
+
+* **security:** harden claude-review workflow and settings ([7752a65](https://github.com/hari-houdini/me-portfolio/commit/7752a65d0ad5d3bda3576b1f84939accb84a59f1)), closes [#2](https://github.com/hari-houdini/me-portfolio/issues/2) [#3](https://github.com/hari-houdini/me-portfolio/issues/3) [#6](https://github.com/hari-houdini/me-portfolio/issues/6) [#7](https://github.com/hari-houdini/me-portfolio/issues/7) [#5](https://github.com/hari-houdini/me-portfolio/issues/5) [#1](https://github.com/hari-houdini/me-portfolio/issues/1) [#4](https://github.com/hari-houdini/me-portfolio/issues/4) [#8](https://github.com/hari-houdini/me-portfolio/issues/8) [#9](https://github.com/hari-houdini/me-portfolio/issues/9)
+
+
+### Features
+
+* **claude-review:** v2 — filtered diff, findings cache, severity tiers, hard gate ([94223c0](https://github.com/hari-houdini/me-portfolio/commit/94223c0d2b3b7f878798e0ff99809888b45cb27e))
+
 # 1.0.0 (2026-03-23)
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An immersive, single-page 3D portfolio built with React Three Fiber, custom GLSL shaders, and procedural generation. Every visual is authored code — no purchased assets.
 
-> **Status:** Phase 1 complete — foundation, CMS service layer, and test infrastructure.
+> **Status:** Phase 2 complete — Payload CMS v3 schema, collections, globals, and Railway deployment config.
 > See [PRD-001](./agents/docs/PRD-001-immersive-portfolio.md) for the full specification and [GitHub Issue #1](https://github.com/hari-houdini/me-portfolio/issues/1) for the requirement breakdown.
 
 ---
@@ -19,7 +19,7 @@ An immersive, single-page 3D portfolio built with React Three Fiber, custom GLSL
 | Accessibility | React Aria Components |
 | Service Layer | Effect-ts (Layer DI · Effect.Effect · typed errors) |
 | Schema & Validation | Zod v4 (schemas as source of truth · z.infer<> types) |
-| CMS | Payload CMS v3 + Next.js 15 (`cms/` subfolder) |
+| CMS | Payload CMS v3 + Next.js 16 (`cms/` subfolder) |
 | CMS DB | PostgreSQL via Supabase |
 | CMS Hosting | Railway.app |
 | Edge Deployment | Cloudflare Workers (Hono middleware) |
@@ -58,7 +58,15 @@ me-portfolio/
 │   └── app.css                 # Tailwind v4, cyberpunk palette, typography
 ├── workers/
 │   └── app.ts                  # Cloudflare Workers entry (Hono + RR7 handler)
-├── cms/                        # Payload CMS v3 + Next.js 15 (Phase 2)
+├── cms/                        # Payload CMS v3 + Next.js 16 (complete)
+│   ├── src/
+│   │   ├── access/             # isAdmin access control function
+│   │   ├── collections/        # Users, Media, Projects
+│   │   ├── globals/            # SiteConfig, About, Contact
+│   │   └── payload.config.ts   # Main Payload config (DB, editor, CORS, sharp)
+│   ├── app/(payload)/          # Next.js admin panel + REST API routes
+│   ├── railway.json            # Railway deployment config
+│   └── .env.example            # Required environment variables
 ├── agents/
 │   └── docs/
 │       └── PRD-001-immersive-portfolio.md
@@ -124,22 +132,66 @@ pnpm check
 
 ---
 
-## CMS Setup (Phase 2)
+## CMS Setup
 
-The Payload CMS lives in `cms/` and runs as a separate Next.js 15 application.
+The Payload CMS lives in `cms/` and runs as a separate Next.js 16 application.
+
+### Local development
 
 ```bash
-# From the cms/ directory
-pnpm install
-pnpm dev        # admin panel at http://localhost:3001/admin
+# 1. Copy environment file and fill in your values
+cp cms/.env.example cms/.env
+
+# 2. Install CMS dependencies
+cd cms && pnpm install
+
+# 3. Start the CMS dev server (admin panel at http://localhost:3001/admin)
+pnpm dev
 ```
 
-Set `PAYLOAD_API_URL` in your environment to point the portfolio server at the CMS:
+On first run, navigate to `http://localhost:3001/admin/create-first-user` to create your admin account.
+
+### Required environment variables (`cms/.env`)
+
+| Variable | Description |
+|---|---|
+| `DATABASE_URI` | PostgreSQL connection string (Supabase: Settings → Database → URI) |
+| `PAYLOAD_SECRET` | Random 32-char secret: `openssl rand -hex 32` |
+| `NEXT_PUBLIC_SERVER_URL` | CMS origin (e.g. `http://localhost:3001`) |
+| `PORTFOLIO_URL` | Portfolio origin, added to CMS CORS allow-list |
+
+### Pointing the portfolio at the CMS
+
+Set `PAYLOAD_API_URL` in the **portfolio** app's environment:
 
 ```bash
-# .env (local)
+# portfolio/.env (local)
 PAYLOAD_API_URL=http://localhost:3001
 ```
+
+### CMS schema
+
+| Resource | Slug | Type | Key fields |
+|---|---|---|---|
+| Users | `users` | Collection | email, password (auth built-in) |
+| Media | `media` | Collection | file, alt, imageSizes: thumbnail (400px), og (1200×630) |
+| Projects | `projects` | Collection | title, description, thumbnail, tags, url, github, featured, year, status, order |
+| Site Config | `site-config` | Global | name, tagline, subtitle, sectionTitles, seo (metaTitle, metaDescription, ogImage) |
+| About | `about` | Global | bio (richText), skills array, photo |
+| Contact | `contact` | Global | email, ctaText, socials array (platform, url, label) |
+
+### Payload array-of-objects format
+
+Payload wraps every `array` field item in an object with an auto-generated `id`:
+
+```
+tags → [{ id: "abc", tag: "React" }]     (Payload API)
+     → ["React"]                          (after Zod transform)
+```
+
+The portfolio's Zod schemas handle this transparently via a union transform that
+accepts both the Payload object format AND plain strings (used in test fixtures).
+No change is needed in the consuming components — they always receive `string[]`.
 
 ---
 
@@ -162,13 +214,22 @@ Configure `PAYLOAD_API_URL` as a Wrangler environment variable in `wrangler.toml
 
 ### CMS — Railway.app
 
-Push `cms/` to Railway. Set the following environment variables:
+```bash
+# From your Railway project, link the cms/ directory and set env vars
+railway up --service cms
+```
+
+Set the following environment variables in Railway:
 
 | Variable | Description |
 |---|---|
-| `DATABASE_URI` | Supabase PostgreSQL connection string |
-| `PAYLOAD_SECRET` | Random 32-character secret |
-| `NEXT_PUBLIC_SERVER_URL` | The Railway deployment URL |
+| `DATABASE_URI` | Supabase PostgreSQL connection string (SSL required) |
+| `PAYLOAD_SECRET` | Random 32-character secret (`openssl rand -hex 32`) |
+| `NEXT_PUBLIC_SERVER_URL` | The Railway public domain for this service |
+| `PORTFOLIO_URL` | `https://harihoudini.dev` (for CORS) |
+
+Railway uses `pnpm start` (configured in `cms/railway.json`) which runs `next start --port 3001`.
+The CMS build produces a standalone Next.js output for minimal image size.
 
 ---
 
@@ -220,8 +281,8 @@ Every API response is validated at runtime via `schema.safeParse()`. A structura
 |---|---|---|
 | Phase 0 | ✅ Complete | PRD, architecture decisions, GitHub issue |
 | Phase 1 | ✅ Complete | Foundation: deps, build, CMS service layer, tests |
-| Phase 2 | 🔜 Next | Payload CMS setup, collections, globals, REST API |
-| Phase 3 | Planned | 3D experience: galaxy + cyberpunk city + scroll |
+| Phase 2 | ✅ Complete | Payload CMS v3: collections (Users, Media, Projects), globals (SiteConfig, About, Contact), Railway deploy config |
+| Phase 3 | 🔜 Next | 3D experience: galaxy + cyberpunk city + scroll |
 | Phase 4 | Planned | Content + polish: overlays, audio, mobile fallback, a11y |
 | Phase 5 | Planned | Deploy: Cloudflare Workers + Railway + Supabase |
 

--- a/app/services/cms/cms.schemas.ts
+++ b/app/services/cms/cms.schemas.ts
@@ -13,11 +13,44 @@
  *    not by this service layer.
  *  - Nullable fields match the Payload REST API contract from PRD-001 §4.6.
  *
+ * Payload array-of-objects format:
+ *  Payload's `array` field type wraps each item in an object with an auto-
+ *  generated `id`. For example, tags come back as [{id:"abc", tag:"React"}].
+ *  We use a union schema that accepts BOTH the raw Payload format AND a plain
+ *  string (used in test fixtures), then transform to string[]. This means:
+ *   - Real Payload API responses validate correctly
+ *   - Test fixtures can use the simpler string[] format
+ *   - z.infer<> gives string[] (the normalised domain type)
+ *
  * Barrel exports: all schemas and inferred types are re-exported from mod.ts.
  * Consumers outside this pod import from mod.ts only.
  */
 
 import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Internal helpers for Payload's array-of-objects fields
+// ---------------------------------------------------------------------------
+
+/**
+ * Accepts either a plain string or a Payload array-item object { id?, [field] }.
+ * Transforms to string[]. Works with both real API responses and test fixtures.
+ */
+const payloadTagArray = (fieldName: string) =>
+	z
+		.array(
+			z.union([
+				z.string(),
+				z.object({ id: z.string().optional(), [fieldName]: z.string() }),
+			]),
+		)
+		.transform((arr) =>
+			arr.map((item) =>
+				typeof item === "string"
+					? item
+					: ((item as Record<string, string>)[fieldName] ?? ""),
+			),
+		);
 
 // ---------------------------------------------------------------------------
 // Shared sub-schemas
@@ -40,7 +73,14 @@ export const MediaObjectSchema = z.object({
 	}),
 });
 
+/**
+ * SocialLinkSchema
+ *
+ * Payload's `array` field adds an `id` to each social link item.
+ * `id` is optional so the schema also accepts fixtures without it.
+ */
 export const SocialLinkSchema = z.object({
+	id: z.string().optional(),
 	platform: z.string(),
 	url: z.string(),
 	label: z.string(),
@@ -70,7 +110,11 @@ export const SiteConfigSchema = z.object({
 export const AboutSchema = z.object({
 	/** Lexical rich-text document — shape consumed by the renderer in Phase 3. */
 	bio: z.unknown(),
-	skills: z.array(z.string()),
+	/**
+	 * Payload returns [{id, skill: "React"}]. The union transform normalises
+	 * this to string[] while also accepting plain strings from test fixtures.
+	 */
+	skills: payloadTagArray("skill"),
 	photo: MediaObjectSchema.nullable(),
 });
 
@@ -91,7 +135,11 @@ export const ProjectSchema = z.object({
 	/** Lexical rich-text document — shape consumed by the renderer in Phase 3. */
 	longDescription: z.unknown(),
 	thumbnail: MediaObjectSchema.nullable(),
-	tags: z.array(z.string()),
+	/**
+	 * Payload returns [{id, tag: "React"}]. The union transform normalises
+	 * this to string[] while also accepting plain strings from test fixtures.
+	 */
+	tags: payloadTagArray("tag"),
 	url: z.string().nullable(),
 	github: z.string().nullable(),
 	featured: z.boolean(),

--- a/cms/.env.example
+++ b/cms/.env.example
@@ -1,0 +1,23 @@
+# ============================================================
+# Payload CMS — Environment Variables
+# Copy this file to .env and fill in the values.
+# NEVER commit .env to version control.
+# ============================================================
+
+# PostgreSQL connection string (Supabase free tier)
+# Found in: Supabase project → Settings → Database → Connection string (URI mode)
+DATABASE_URI=postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-PROJECT-REF].supabase.co:5432/postgres?sslmode=require
+
+# Payload secret — used for password hashing and session tokens
+# Generate with: openssl rand -hex 32
+PAYLOAD_SECRET=your-32-character-secret-here
+
+# The URL where this CMS is hosted (no trailing slash)
+# Local:      http://localhost:3001
+# Production: https://cms.harihoudini.dev
+NEXT_PUBLIC_SERVER_URL=http://localhost:3001
+
+# Portfolio URL — added to the CORS allow-list
+# Local:      http://localhost:5173
+# Production: https://harihoudini.dev
+PORTFOLIO_URL=http://localhost:5173

--- a/cms/app/(payload)/admin/[[...segments]]/not-found.tsx
+++ b/cms/app/(payload)/admin/[[...segments]]/not-found.tsx
@@ -1,0 +1,20 @@
+/**
+ * app/(payload)/admin/[[...segments]]/not-found.tsx
+ *
+ * Payload admin 404 handler. Delegates to Payload's NotFoundPage component.
+ * The empty importMap is correct for a config with no custom React components.
+ */
+
+import config from "@payload-config";
+import { NotFoundPage } from "@payloadcms/next/views";
+
+const importMap = {};
+
+type Args = {
+	params: Promise<{ segments: string[] }>;
+	searchParams: Promise<{ [key: string]: string | string[] }>;
+};
+
+export default async function NotFound({ params, searchParams }: Args) {
+	return NotFoundPage({ config, importMap, params, searchParams });
+}

--- a/cms/app/(payload)/admin/[[...segments]]/page.tsx
+++ b/cms/app/(payload)/admin/[[...segments]]/page.tsx
@@ -1,0 +1,34 @@
+/**
+ * app/(payload)/admin/[[...segments]]/page.tsx
+ *
+ * Payload admin panel catch-all route. Delegates all rendering to Payload's
+ * RootPage component.
+ *
+ * importMap:
+ *   Payload uses an import map to resolve custom React components registered
+ *   in the config (custom admin views, cells, field components, etc.).
+ *   This portfolio CMS has no custom components, so the import map is empty.
+ *   If you add custom components, run `pnpm generate:importmap` to regenerate.
+ */
+
+import config from "@payload-config";
+import { generatePageMetadata, RootPage } from "@payloadcms/next/views";
+import type { Metadata } from "next";
+
+// No custom Payload components → empty import map.
+const importMap = {};
+
+type Args = {
+	params: Promise<{ segments: string[] }>;
+	searchParams: Promise<{ [key: string]: string | string[] }>;
+};
+
+export const generateMetadata = ({
+	params,
+	searchParams,
+}: Args): Promise<Metadata> =>
+	generatePageMetadata({ config, params, searchParams });
+
+export default function AdminPage({ params, searchParams }: Args) {
+	return RootPage({ config, importMap, params, searchParams });
+}

--- a/cms/app/(payload)/api/[...slug]/route.ts
+++ b/cms/app/(payload)/api/[...slug]/route.ts
@@ -1,0 +1,38 @@
+/**
+ * app/(payload)/api/[...slug]/route.ts
+ *
+ * Payload REST API + GraphQL catch-all route handler.
+ *
+ * REST_GET / REST_POST / etc. are curried: they take the config first and
+ * return a Next.js route handler. This file is provided by the Payload
+ * Next.js integration template and should not be modified.
+ *
+ * Endpoints exposed:
+ *  GET    /api/globals/{slug}              — fetch a global
+ *  PATCH  /api/globals/{slug}              — update a global (auth required)
+ *  GET    /api/{collection}                — list collection documents
+ *  GET    /api/{collection}/{id}           — fetch a single document
+ *  POST   /api/{collection}                — create (auth required)
+ *  PATCH  /api/{collection}/{id}           — update (auth required)
+ *  DELETE /api/{collection}/{id}           — delete (auth required)
+ *  POST   /api/{users-slug}/login          — authenticate
+ *  POST   /api/{users-slug}/logout         — sign out
+ *  POST   /api/{users-slug}/refresh-token  — refresh JWT
+ */
+
+import configPromise from "@payload-config";
+import {
+	REST_DELETE,
+	REST_GET,
+	REST_OPTIONS,
+	REST_PATCH,
+	REST_POST,
+	REST_PUT,
+} from "@payloadcms/next/routes";
+
+export const GET = REST_GET(configPromise);
+export const POST = REST_POST(configPromise);
+export const PUT = REST_PUT(configPromise);
+export const PATCH = REST_PATCH(configPromise);
+export const DELETE = REST_DELETE(configPromise);
+export const OPTIONS = REST_OPTIONS(configPromise);

--- a/cms/app/(payload)/layout.tsx
+++ b/cms/app/(payload)/layout.tsx
@@ -1,0 +1,16 @@
+/**
+ * app/(payload)/layout.tsx
+ *
+ * Payload's admin panel layout. This file must exist and re-export children
+ * as-is — Payload renders its own full-page layout internally. Do not add
+ * custom HTML structure here.
+ *
+ * This file is provided by the Payload Next.js integration template and
+ * should not be modified.
+ */
+
+import type React from "react";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+	return <>{children}</>;
+}

--- a/cms/app/layout.tsx
+++ b/cms/app/layout.tsx
@@ -1,0 +1,21 @@
+/**
+ * app/layout.tsx — root Next.js layout
+ *
+ * This is the minimal root layout required by Next.js 16 App Router.
+ * Payload's admin panel is rendered inside the (payload) route group,
+ * which has its own layout (app/(payload)/layout.tsx).
+ */
+
+import type React from "react";
+
+export default function RootLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<html lang="en">
+			<body>{children}</body>
+		</html>
+	);
+}

--- a/cms/biome.json
+++ b/cms/biome.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+	"root": false,
+	"extends": ["../biome.json"]
+}

--- a/cms/next.config.ts
+++ b/cms/next.config.ts
@@ -1,0 +1,18 @@
+import { withPayload } from "@payloadcms/next/withPayload";
+import type { NextConfig } from "next";
+
+/**
+ * next.config.ts
+ *
+ * withPayload wraps the Next.js config to:
+ *  - Ensure compatibility with Payload's dependencies (drizzle-kit, etc.)
+ *  - Configure the @payload-config path alias for Next.js bundling
+ *  - Enable the Payload admin panel via the (payload) app route group
+ */
+const nextConfig: NextConfig = {
+	// output: 'standalone' produces a self-contained build suitable for Docker
+	// and Railway deployment — no node_modules mount required.
+	output: "standalone",
+};
+
+export default withPayload(nextConfig);

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "harihoudini-cms",
+	"version": "0.1.0",
+	"description": "Payload CMS for harihoudini.dev — content management for the immersive 3D portfolio",
+	"license": "MIT",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "next dev --port 3001",
+		"build": "next build",
+		"start": "next start --port 3001",
+		"generate:types": "payload generate:types",
+		"generate:importmap": "payload generate:importmap",
+		"check": "biome check --write",
+		"lint": "biome lint --write"
+	},
+	"dependencies": {
+		"@payloadcms/db-postgres": "^3.80.0",
+		"@payloadcms/next": "^3.80.0",
+		"@payloadcms/richtext-lexical": "^3.80.0",
+		"next": "^16.2.1",
+		"payload": "^3.80.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"sharp": "^0.34.5"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.4.8",
+		"@types/node": "^22.0.0",
+		"@types/react": "^19.0.0",
+		"@types/react-dom": "^19.0.0",
+		"typescript": "^5.9.0"
+	},
+	"engines": {
+		"node": ">=20.9.0"
+	}
+}

--- a/cms/railway.json
+++ b/cms/railway.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://railway.app/railway.schema.json",
+	"build": {
+		"builder": "NIXPACKS"
+	},
+	"deploy": {
+		"startCommand": "pnpm start",
+		"restartPolicyType": "ON_FAILURE",
+		"restartPolicyMaxRetries": 5
+	}
+}

--- a/cms/src/access/is-admin.access.ts
+++ b/cms/src/access/is-admin.access.ts
@@ -1,0 +1,17 @@
+/**
+ * is-admin.access.ts
+ *
+ * Access control function that grants permission only to authenticated users.
+ *
+ * Applied to all write operations (create, update, delete) across every
+ * collection and global. Read access is intentionally left public so the
+ * portfolio can fetch CMS data without authentication.
+ *
+ * In Payload v3, the `user` on the request is populated by Payload's built-in
+ * auth middleware after a successful login. A falsy user means the request is
+ * unauthenticated.
+ */
+
+import type { Access } from "payload";
+
+export const isAdmin: Access = ({ req: { user } }) => Boolean(user);

--- a/cms/src/collections/Media.ts
+++ b/cms/src/collections/Media.ts
@@ -1,0 +1,62 @@
+/**
+ * Media.ts
+ *
+ * Payload upload collection for all portfolio images.
+ *
+ * Image size variants:
+ *  - thumbnail (400px wide) — used in project cards
+ *  - og (1200×630)          — used for Open Graph / social share previews
+ *
+ * Access:
+ *  - read:   public (images are served directly)
+ *  - write:  admin only
+ */
+
+import type { CollectionConfig } from "payload";
+import { isAdmin } from "../access/is-admin.access";
+
+export const Media: CollectionConfig = {
+	slug: "media",
+	admin: {
+		useAsTitle: "filename",
+		description: "Images and media assets used across the portfolio.",
+	},
+	access: {
+		read: () => true,
+		create: isAdmin,
+		update: isAdmin,
+		delete: isAdmin,
+	},
+	upload: {
+		// staticDir is relative to the project root — served at /media/**
+		staticDir: "media",
+		imageSizes: [
+			{
+				name: "thumbnail",
+				width: 400,
+				// height is left undefined — aspect ratio is preserved
+				position: "centre",
+			},
+			{
+				name: "og",
+				width: 1200,
+				height: 630,
+				position: "centre",
+			},
+		],
+		// Which size to display as the preview image in the admin panel
+		adminThumbnail: "thumbnail",
+		mimeTypes: ["image/*"],
+	},
+	fields: [
+		{
+			name: "alt",
+			type: "text",
+			label: "Alt Text",
+			admin: {
+				description:
+					'Describe the image for screen readers. Leave empty for purely decorative images and add role="presentation" in the component.',
+			},
+		},
+	],
+};

--- a/cms/src/collections/Projects.ts
+++ b/cms/src/collections/Projects.ts
@@ -1,0 +1,146 @@
+/**
+ * Projects.ts
+ *
+ * Portfolio projects collection.
+ *
+ * PRD-001 §4.5 schema: title, description, thumbnail, tags, url, github,
+ * featured, year, status (draft|published), order.
+ *
+ * REST API endpoint: GET /api/projects
+ *   - Filter published:  ?where[status][equals]=published
+ *   - Sort by order:     &sort=order
+ *
+ * Note on tags field:
+ *   Payload's array field wraps each item in an object: [{id, tag: "React"}].
+ *   The portfolio's Zod schema handles this via a union transform that accepts
+ *   both the raw Payload format and plain strings (used in test fixtures).
+ *
+ * Access:
+ *  - read:   public (portfolio fetches published projects without auth)
+ *  - write:  admin only
+ */
+
+import type { CollectionConfig } from "payload";
+import { isAdmin } from "../access/is-admin.access";
+
+export const Projects: CollectionConfig = {
+	slug: "projects",
+	admin: {
+		useAsTitle: "title",
+		defaultColumns: ["title", "year", "status", "featured", "order"],
+		description: "Portfolio projects shown in the work section.",
+	},
+	access: {
+		read: () => true,
+		create: isAdmin,
+		update: isAdmin,
+		delete: isAdmin,
+	},
+	fields: [
+		// ---- Core -------------------------------------------------------
+		{
+			name: "title",
+			type: "text",
+			required: true,
+		},
+		{
+			name: "description",
+			type: "textarea",
+			required: true,
+			admin: {
+				description: "Short summary shown in the project card.",
+			},
+		},
+		{
+			name: "longDescription",
+			type: "richText",
+			label: "Long Description",
+			admin: {
+				description: "Full write-up. Supports rich text formatting.",
+			},
+		},
+		// ---- Media ------------------------------------------------------
+		{
+			name: "thumbnail",
+			type: "upload",
+			relationTo: "media",
+			label: "Thumbnail",
+			admin: {
+				description: "Displayed in the project card. Recommended: 800×600.",
+			},
+		},
+		// ---- Classification ---------------------------------------------
+		{
+			name: "tags",
+			type: "array",
+			label: "Technology Tags",
+			admin: {
+				description: 'e.g. "React", "Three.js", "TypeScript"',
+			},
+			fields: [
+				{
+					name: "tag",
+					type: "text",
+					required: true,
+				},
+			],
+		},
+		{
+			name: "year",
+			type: "number",
+			admin: {
+				description: "Year the project was completed.",
+			},
+		},
+		// ---- Links ------------------------------------------------------
+		{
+			name: "url",
+			type: "text",
+			label: "Live URL",
+			admin: {
+				description: "Link to the deployed project.",
+			},
+		},
+		{
+			name: "github",
+			type: "text",
+			label: "GitHub URL",
+			admin: {
+				description: "Link to the GitHub repository.",
+			},
+		},
+		// ---- Display ----------------------------------------------------
+		{
+			name: "featured",
+			type: "checkbox",
+			label: "Featured",
+			defaultValue: false,
+			admin: {
+				description:
+					"Featured projects are pinned to the top of the work section.",
+			},
+		},
+		{
+			name: "order",
+			type: "number",
+			admin: {
+				description: "Manual display order. Lower numbers appear first.",
+			},
+		},
+		// ---- Status -----------------------------------------------------
+		{
+			name: "status",
+			type: "select",
+			required: true,
+			defaultValue: "draft",
+			options: [
+				{ label: "Draft", value: "draft" },
+				{ label: "Published", value: "published" },
+			],
+			admin: {
+				description: "Only published projects are shown on the portfolio.",
+				position: "sidebar",
+			},
+		},
+	],
+};

--- a/cms/src/collections/Users.ts
+++ b/cms/src/collections/Users.ts
@@ -1,0 +1,25 @@
+/**
+ * Users.ts
+ *
+ * Payload's built-in auth collection.
+ *
+ * Only admins can access the admin panel — Payload's auth system handles
+ * password hashing, session management, and JWT issuance automatically.
+ * The first user created via /admin/create-first-user becomes the sole admin.
+ */
+
+import type { CollectionConfig } from "payload";
+
+export const Users: CollectionConfig = {
+	slug: "users",
+	admin: {
+		useAsTitle: "email",
+		description: "Admin users who can manage content in the CMS.",
+	},
+	// auth: true enables Payload's built-in authentication for this collection.
+	// This provides login, logout, password reset, and token refresh endpoints.
+	auth: true,
+	fields: [
+		// Email is provided automatically by Payload auth — no explicit field needed.
+	],
+};

--- a/cms/src/globals/About.ts
+++ b/cms/src/globals/About.ts
@@ -1,0 +1,65 @@
+/**
+ * About.ts
+ *
+ * Singleton global — bio rich text, skills list, and portrait photo.
+ *
+ * REST API endpoint: GET /api/globals/about
+ *
+ * Note on skills field:
+ *   Payload wraps each array item in an object: [{id, skill: "React"}].
+ *   The portfolio Zod schema handles this via a union transform.
+ *
+ * Access:
+ *  - read:   public
+ *  - update: admin only
+ */
+
+import type { GlobalConfig } from "payload";
+import { isAdmin } from "../access/is-admin.access";
+
+export const About: GlobalConfig = {
+	slug: "about",
+	label: "About",
+	admin: {
+		description: "Biography, skills, and portrait photo for the About section.",
+	},
+	access: {
+		read: () => true,
+		update: isAdmin,
+	},
+	fields: [
+		{
+			name: "bio",
+			type: "richText",
+			label: "Biography",
+			admin: {
+				description: "Your bio shown in the About section. Supports rich text.",
+			},
+		},
+		{
+			name: "skills",
+			type: "array",
+			label: "Skills / Technologies",
+			admin: {
+				description:
+					'List of technologies you work with, e.g. "React", "TypeScript".',
+			},
+			fields: [
+				{
+					name: "skill",
+					type: "text",
+					required: true,
+				},
+			],
+		},
+		{
+			name: "photo",
+			type: "upload",
+			relationTo: "media",
+			label: "Portrait Photo",
+			admin: {
+				description: "Optional headshot displayed in the About section.",
+			},
+		},
+	],
+};

--- a/cms/src/globals/Contact.ts
+++ b/cms/src/globals/Contact.ts
@@ -1,0 +1,83 @@
+/**
+ * Contact.ts
+ *
+ * Singleton global — email, call-to-action text, and social links.
+ *
+ * REST API endpoint: GET /api/globals/contact
+ *
+ * Access:
+ *  - read:   public
+ *  - update: admin only
+ */
+
+import type { GlobalConfig } from "payload";
+import { isAdmin } from "../access/is-admin.access";
+
+export const Contact: GlobalConfig = {
+	slug: "contact",
+	label: "Contact",
+	admin: {
+		description: "Email address, CTA text, and social media links.",
+	},
+	access: {
+		read: () => true,
+		update: isAdmin,
+	},
+	fields: [
+		{
+			name: "email",
+			type: "email",
+			required: true,
+			defaultValue: "hello@harihoudini.dev",
+		},
+		{
+			name: "ctaText",
+			type: "text",
+			label: "Call-to-Action Text",
+			defaultValue: "Let's work together",
+			admin: {
+				description:
+					'The label on the contact button, e.g. "Let\'s work together".',
+			},
+		},
+		{
+			name: "socials",
+			type: "array",
+			label: "Social Links",
+			admin: {
+				description: "Social media profiles shown in the contact section.",
+			},
+			fields: [
+				{
+					name: "platform",
+					type: "select",
+					required: true,
+					options: [
+						{ label: "GitHub", value: "github" },
+						{ label: "Twitter / X", value: "twitter" },
+						{ label: "LinkedIn", value: "linkedin" },
+						{ label: "Instagram", value: "instagram" },
+						{ label: "YouTube", value: "youtube" },
+						{ label: "Dribbble", value: "dribbble" },
+					],
+				},
+				{
+					name: "url",
+					type: "text",
+					required: true,
+					admin: {
+						description: "Full URL including https://",
+					},
+				},
+				{
+					name: "label",
+					type: "text",
+					required: true,
+					admin: {
+						description: 'Display label, e.g. "GitHub" or "@hari_houdini".',
+					},
+				},
+			],
+		},
+	],
+};

--- a/cms/src/globals/SiteConfig.ts
+++ b/cms/src/globals/SiteConfig.ts
@@ -1,0 +1,112 @@
+/**
+ * SiteConfig.ts
+ *
+ * Singleton global — controls all heading copy and SEO metadata for the portfolio.
+ *
+ * REST API endpoint: GET /api/globals/site-config
+ *
+ * Access:
+ *  - read:   public
+ *  - update: admin only
+ */
+
+import type { GlobalConfig } from "payload";
+import { isAdmin } from "../access/is-admin.access";
+
+export const SiteConfig: GlobalConfig = {
+	slug: "site-config",
+	label: "Site Configuration",
+	admin: {
+		description:
+			"Portfolio title, tagline, section headings, and SEO metadata.",
+	},
+	access: {
+		read: () => true,
+		update: isAdmin,
+	},
+	fields: [
+		// ---- Identity ---------------------------------------------------
+		{
+			name: "name",
+			type: "text",
+			required: true,
+			defaultValue: "Hari Houdini",
+			admin: {
+				description: "Your full name — displayed as the 3D hero title.",
+			},
+		},
+		{
+			name: "tagline",
+			type: "text",
+			required: true,
+			defaultValue: "Creative Technologist",
+			admin: {
+				description: "Your title or role — displayed below the hero name.",
+			},
+		},
+		{
+			name: "subtitle",
+			type: "text",
+			admin: {
+				description: "Optional secondary line in the hero section.",
+			},
+		},
+		// ---- Section titles ---------------------------------------------
+		{
+			name: "sectionTitles",
+			type: "group",
+			label: "Section Titles",
+			fields: [
+				{
+					name: "hero",
+					type: "text",
+					defaultValue: "Hello, Universe",
+				},
+				{
+					name: "about",
+					type: "text",
+					defaultValue: "About",
+				},
+				{
+					name: "work",
+					type: "text",
+					defaultValue: "Work",
+				},
+				{
+					name: "contact",
+					type: "text",
+					defaultValue: "Contact",
+				},
+			],
+		},
+		// ---- SEO --------------------------------------------------------
+		{
+			name: "seo",
+			type: "group",
+			label: "SEO",
+			fields: [
+				{
+					name: "metaTitle",
+					type: "text",
+					defaultValue: "Hari Houdini — Creative Technologist",
+				},
+				{
+					name: "metaDescription",
+					type: "textarea",
+					defaultValue:
+						"Portfolio of Hari Houdini — immersive 3D experiences built at the intersection of art and engineering.",
+				},
+				{
+					name: "ogImage",
+					type: "upload",
+					relationTo: "media",
+					label: "OG Image",
+					admin: {
+						description:
+							"Open Graph image shown when sharing on social media. Recommended: 1200×630.",
+					},
+				},
+			],
+		},
+	],
+};

--- a/cms/src/payload.config.ts
+++ b/cms/src/payload.config.ts
@@ -1,0 +1,90 @@
+/**
+ * payload.config.ts
+ *
+ * Main Payload CMS configuration for harihoudini.dev.
+ *
+ * Architecture:
+ *  - PostgreSQL via @payloadcms/db-postgres (Supabase free tier in production)
+ *  - Lexical rich text editor for bio and project long descriptions
+ *  - Sharp for server-side image resizing (thumbnail + og size variants)
+ *  - CORS allow-list: portfolio origin + CMS origin
+ *  - Telemetry disabled
+ *
+ * REST API base: {NEXT_PUBLIC_SERVER_URL}/api
+ *   Globals: /api/globals/{slug}
+ *   Collections: /api/{slug}
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { postgresAdapter } from "@payloadcms/db-postgres";
+import { lexicalEditor } from "@payloadcms/richtext-lexical";
+import { buildConfig } from "payload";
+import sharp from "sharp";
+import { Media } from "./collections/Media";
+import { Projects } from "./collections/Projects";
+import { Users } from "./collections/Users";
+import { About } from "./globals/About";
+import { Contact } from "./globals/Contact";
+import { SiteConfig } from "./globals/SiteConfig";
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
+export default buildConfig({
+	// ---- Server ---------------------------------------------------------
+	serverURL: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3001",
+
+	// ---- Admin panel ----------------------------------------------------
+	admin: {
+		user: Users.slug,
+		meta: {
+			titleSuffix: "— harihoudini.dev CMS",
+		},
+	},
+
+	// ---- Collections & Globals ------------------------------------------
+	collections: [Users, Media, Projects],
+	globals: [SiteConfig, About, Contact],
+
+	// ---- Editor ---------------------------------------------------------
+	// lexicalEditor() is the default rich text editor. Applied globally;
+	// individual richText fields inherit this unless they override it.
+	editor: lexicalEditor(),
+
+	// ---- Auth -----------------------------------------------------------
+	secret: process.env.PAYLOAD_SECRET ?? "",
+
+	// ---- Database -------------------------------------------------------
+	db: postgresAdapter({
+		pool: {
+			connectionString: process.env.DATABASE_URI ?? "",
+		},
+	}),
+
+	// ---- Image processing -----------------------------------------------
+	// sharp enables server-side cropping, focal-point selection, and the
+	// imageSizes defined in the Media collection.
+	sharp,
+
+	// ---- CORS -----------------------------------------------------------
+	// Allows the portfolio app to call the CMS REST API from the browser.
+	cors: {
+		origins: [
+			// CMS itself (admin panel XHR)
+			process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3001",
+			// Portfolio app (client-side data fetching, if ever needed)
+			process.env.PORTFOLIO_URL ?? "http://localhost:5173",
+			// Production portfolio domain
+			"https://harihoudini.dev",
+		].filter(Boolean),
+	},
+
+	// ---- TypeScript type generation -------------------------------------
+	typescript: {
+		outputFile: path.resolve(dirname, "payload-types.ts"),
+	},
+
+	// ---- Telemetry ------------------------------------------------------
+	telemetry: false,
+});

--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -1,0 +1,34 @@
+{
+	"compilerOptions": {
+		"lib": ["DOM", "DOM.Iterable", "ES2022"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"@payload-config": ["./src/payload.config.ts"],
+			"@/*": ["./src/*"]
+		},
+		"target": "ES2017"
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
+	],
+	"exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
 		"vitest": "^4.1.0",
 		"wrangler": "^4.76.0"
 	},
-	"version": "1.0.0"
+	"version": "1.1.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		".react-router/types/**/*",
 		"workers/**/*"
 	],
+	"exclude": ["node_modules", "cms/**/*"],
 	"compilerOptions": {
 		"lib": ["DOM", "DOM.Iterable", "ES2022"],
 		"types": ["node", "vite/client"],


### PR DESCRIPTION
## Summary

Implements Phase 2 of [PRD-001](./agents/docs/PRD-001-immersive-portfolio.md).

> **Note:** This PR supersedes the incorrectly-merged PR #3. Phase 2 was merged to `main` without approval — that merge has been reverted. This PR correctly targets `feat/phase-1` so phases stack cleanly before anything reaches `main`.

**Base:** `feat/phase-1` → **Head:** `feat/phase-2`

---

## What's in this PR

### 7 conventional commits (Phase 2 only — no Phase 1 noise)

| # | Commit | Scope |
|---|---|---|
| 1 | `chore(cms)` | Project scaffold: package.json, next.config.ts, tsconfig.json, biome.json, .env.example, railway.json |
| 2 | `feat(cms/access)` | `isAdmin` access control + Users auth collection |
| 3 | `feat(cms/collections)` | Media (upload + imageSizes) + Projects (full PRD schema) |
| 4 | `feat(cms/globals)` | SiteConfig, About, Contact singleton globals |
| 5 | `feat(cms/config)` | payload.config.ts + Next.js admin + REST API routes |
| 6 | `refactor(cms/schemas)` | Zod union transform for Payload array-of-objects format |
| 7 | `docs` | README: Phase 2 CMS guide, schema table, Railway deploy instructions |

---

## CMS schema

| Resource | Slug | Type |
|---|---|---|
| Users | `users` | Auth collection |
| Media | `media` | Upload collection (thumbnail 400px, og 1200×630) |
| Projects | `projects` | Collection (title, description, richText, thumbnail, tags, url, github, featured, year, status, order) |
| Site Config | `site-config` | Global (name, tagline, subtitle, sectionTitles, SEO) |
| About | `about` | Global (bio richText, skills array, photo) |
| Contact | `contact` | Global (email, ctaText, socials array) |

## Zod schema update

Payload's `array` fields return `[{id, tag: "React"}]`. The portfolio's `cms.schemas.ts` now uses a union transform that accepts both the Payload format and plain strings (test fixtures), outputting `string[]` in both cases. All 25 tests pass.

## CMS build

`pnpm build` in `cms/` passes TypeScript + Turbopack compilation cleanly.

## To run locally

```bash
cp cms/.env.example cms/.env   # fill in DATABASE_URI, PAYLOAD_SECRET
cd cms && pnpm install && pnpm dev
# → http://localhost:3001/admin/create-first-user
```