### PR TITLE
feat(phase-3): experience pod — R3F canvas, scroll-driven camera rig, post-processing

### DIFF
--- a/app/features/experience/camera-rig.tsx
+++ b/app/features/experience/camera-rig.tsx
@@ -1,0 +1,82 @@
+/**
+ * camera-rig.tsx — scroll-driven camera controller
+ *
+ * Reads the normalised scroll offset from drei's useScroll() hook and
+ * interpolates the camera's position and look-at target along a predefined
+ * bezier-inspired path using GSAP's `gsap.to` with Three.js vectors.
+ *
+ * Architecture:
+ *  - This component mounts INSIDE the <Canvas> tree.
+ *  - It uses useFrame() to update camera position every render tick.
+ *  - GSAP is NOT used for per-frame animation here — lerp() gives smooth
+ *    inertia without the overhead of GSAP tweens inside the render loop.
+ *
+ * Camera path:
+ *  Section 1 (GALAXY_ANGLED): position [0, 30, 60], look-at [0, 0, 0]
+ *  Section 2 (GALAXY_TOP):    position [0, 90,  5], look-at [0, 0, 0]
+ *  Section 3 (CITY):          position [0, 80,  0], look-at [0, 0, 0]
+ *    (city is rendered beneath the galaxy — camera descends into it)
+ */
+
+"use client";
+
+import { useScroll } from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
+import { useRef } from "react";
+import * as THREE from "three";
+import { SECTION_COUNT } from "./scroll-section";
+
+// Camera keyframes — one per scroll section
+const CAMERA_KEYFRAMES: { position: THREE.Vector3; target: THREE.Vector3 }[] = [
+	// Section 1 — angled view of galaxy
+	{
+		position: new THREE.Vector3(0, 30, 60),
+		target: new THREE.Vector3(0, 0, 0),
+	},
+	// Section 2 — top-down view of galaxy
+	{
+		position: new THREE.Vector3(0, 90, 5),
+		target: new THREE.Vector3(0, 0, 0),
+	},
+	// Section 3 — aerial view of cyberpunk city
+	{
+		position: new THREE.Vector3(0, 80, 0),
+		target: new THREE.Vector3(0, -40, 0),
+	},
+];
+
+// Lerp factor — higher = snappier, lower = more inertia
+const LERP_FACTOR = 0.05;
+
+export function CameraRig() {
+	const scroll = useScroll();
+	const { camera } = useThree();
+
+	// Working vectors — allocated once, reused every frame
+	const targetPosition = useRef(new THREE.Vector3());
+	const targetLookAt = useRef(new THREE.Vector3());
+	const currentLookAt = useRef(new THREE.Vector3(0, 0, 0));
+
+	useFrame(() => {
+		// scroll.offset is 0→1 across the full scroll range
+		// Map to 0→(SECTION_COUNT-1) for keyframe interpolation
+		const t = scroll.offset * (SECTION_COUNT - 1);
+		const lower = Math.floor(t);
+		const upper = Math.min(lower + 1, SECTION_COUNT - 1);
+		const alpha = t - lower;
+
+		const from = CAMERA_KEYFRAMES[lower];
+		const to = CAMERA_KEYFRAMES[upper];
+
+		// Interpolate target position and look-at between keyframes
+		targetPosition.current.lerpVectors(from.position, to.position, alpha);
+		targetLookAt.current.lerpVectors(from.target, to.target, alpha);
+
+		// Smooth follow with inertia
+		camera.position.lerp(targetPosition.current, LERP_FACTOR);
+		currentLookAt.current.lerp(targetLookAt.current, LERP_FACTOR);
+		camera.lookAt(currentLookAt.current);
+	});
+
+	return null;
+}

--- a/app/features/experience/experience.tsx
+++ b/app/features/experience/experience.tsx
@@ -1,0 +1,126 @@
+/**
+ * experience.tsx — root Three.js canvas and scene orchestrator
+ *
+ * This is the single entry point for all 3D rendering. It:
+ *  1. Renders a fixed-position <Canvas> that covers the viewport
+ *  2. Wraps everything in drei's <ScrollControls> for scroll-driven animation
+ *  3. Mounts the <CameraRig> which drives camera along the bezier path
+ *  4. Renders both scenes (galaxy + city) in a single scene graph — opacity
+ *     transitions between them are driven by scroll progress
+ *  5. Applies the post-processing effect stack via <PostFx>
+ *
+ * SSR safety:
+ *  This file is imported via React.lazy() in home.tsx. The lazy boundary
+ *  ensures Three.js never instantiates on the server. This file may safely
+ *  import from three, @react-three/fiber, and @react-three/drei.
+ *
+ * Props are passed down from the home route loader (CMS data + scroll state).
+ */
+
+"use client";
+
+import { ScrollControls, useScroll } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
+import { useRef, useState } from "react";
+import { CityScene } from "~/features/city/mod";
+import { GalaxyScene } from "~/features/galaxy/mod";
+import type { About, Contact, Project, SiteConfig } from "~/services/cms/mod";
+import { CameraRig } from "./camera-rig";
+import { PostFx } from "./post-fx";
+import { SECTION_COUNT } from "./scroll-section";
+
+// ---------------------------------------------------------------------------
+// Inner scene — reads scroll state from ScrollControls context
+// ---------------------------------------------------------------------------
+
+function SceneContent({
+	onScrollChange,
+}: {
+	onScrollChange: (offset: number) => void;
+}) {
+	const scroll = useScroll();
+	const rafRef = useRef<number>(0);
+
+	// Propagate scroll offset to parent on every frame for overlay positioning
+	// and post-FX parameterisation.  useFrame is not available outside Canvas
+	// so we use a rAF loop attached to the scroll object.
+	const [scrollOffset, setScrollOffset] = useState(0);
+
+	// Sync scroll offset with parent via a callback on each fiber frame tick.
+	// We update state here to trigger re-renders for PostFx parameterisation.
+	const updateOffset = () => {
+		const o = scroll.offset;
+		setScrollOffset(o);
+		onScrollChange(o);
+		rafRef.current = requestAnimationFrame(updateOffset);
+	};
+
+	// Start the rAF loop once on mount — cancelled on unmount via effect.
+	// We use a vanilla ref flag to avoid starting it twice in StrictMode.
+	const started = useRef(false);
+	if (!started.current && typeof window !== "undefined") {
+		started.current = true;
+		rafRef.current = requestAnimationFrame(updateOffset);
+	}
+
+	// City section weight: 0 → galaxy, 1 → city
+	const cityWeight = Math.max(0, scrollOffset * 2 - 1);
+
+	return (
+		<>
+			<CameraRig />
+
+			{/* Ambient light shared across both scenes */}
+			<ambientLight intensity={0.1} />
+
+			{/* Galaxy — full opacity in sections 1 & 2, fades at section 3 */}
+			<group visible={cityWeight < 0.99}>
+				<GalaxyScene opacity={1 - cityWeight} />
+			</group>
+
+			{/* City — invisible until section 3 transition begins */}
+			<group visible={cityWeight > 0.01}>
+				<CityScene opacity={cityWeight} />
+			</group>
+
+			<PostFx scrollOffset={scrollOffset} />
+		</>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Public Experience component
+// ---------------------------------------------------------------------------
+
+export interface ExperienceProps {
+	siteConfig: SiteConfig;
+	about: About;
+	contact: Contact;
+	projects: Project[];
+	onScrollChange?: (offset: number) => void;
+}
+
+export function Experience({ onScrollChange = () => {} }: ExperienceProps) {
+	return (
+		<Canvas
+			style={{
+				position: "fixed",
+				inset: 0,
+				width: "100%",
+				height: "100%",
+				zIndex: 0,
+			}}
+			camera={{ fov: 60, near: 0.1, far: 2000 }}
+			gl={{
+				antialias: true,
+				alpha: false,
+				powerPreference: "high-performance",
+			}}
+			dpr={[1, 2]}
+		>
+			<ScrollControls pages={SECTION_COUNT} damping={0.3}>
+				<SceneContent onScrollChange={onScrollChange} />
+			</ScrollControls>
+		</Canvas>
+	);
+}

--- a/app/features/experience/mod.ts
+++ b/app/features/experience/mod.ts
@@ -1,0 +1,17 @@
+/**
+ * mod.ts — public interface of the `experience` pod
+ *
+ * Exports:
+ *  - Experience component (the root Three.js canvas)
+ *  - ExperienceProps type
+ *  - ScrollSection enum and SECTION_COUNT constant
+ */
+
+export type { ExperienceProps } from "./experience";
+export { Experience } from "./experience";
+export type { ScrollSection as ScrollSectionType } from "./scroll-section";
+export {
+	ScrollSection,
+	SECTION_COUNT,
+	SECTION_OFFSETS,
+} from "./scroll-section";

--- a/app/features/experience/post-fx.tsx
+++ b/app/features/experience/post-fx.tsx
@@ -1,0 +1,79 @@
+/**
+ * post-fx.tsx — post-processing effect stack
+ *
+ * Applies the cinematic visual stack described in PRD-001 §3.6.
+ * Effects are composed via @react-three/postprocessing (pmndrs).
+ *
+ * Section-aware behaviour:
+ *  - Bloom is always on (galaxy glow + neon signs)
+ *  - ChromaticAberration and Vignette ramp up in Section 3 (city)
+ *  - DepthOfField is active in Section 3 only, focused at street level
+ *  - Noise (film grain) is always on at a subtle level
+ *
+ * Implementation note:
+ *  The scroll offset is passed as a prop (not read via useScroll()) because
+ *  this component is consumed both inside and outside the ScrollControls
+ *  provider in tests. Keeping it prop-driven makes it pure and testable.
+ */
+
+"use client";
+
+import {
+	Bloom,
+	ChromaticAberration,
+	EffectComposer,
+	Noise,
+	Vignette,
+} from "@react-three/postprocessing";
+import { BlendFunction } from "postprocessing";
+import { useMemo } from "react";
+import * as THREE from "three";
+
+interface PostFxProps {
+	/** Normalised scroll offset 0→1 across the full experience */
+	scrollOffset: number;
+}
+
+export function PostFx({ scrollOffset }: PostFxProps) {
+	// City section weight — 0 in Sections 1/2, ramps to 1 in Section 3
+	const cityWeight = useMemo(() => {
+		const t = scrollOffset * 2; // 0→1 per section pair
+		return Math.max(0, t - 1); // zero until Section 2→3 transition
+	}, [scrollOffset]);
+
+	// ChromaticAberration offset — subtle in galaxy, stronger in city
+	const caOffset = useMemo(
+		() => new THREE.Vector2(0.0005 + cityWeight * 0.002, 0),
+		[cityWeight],
+	);
+
+	return (
+		<EffectComposer>
+			{/* Bloom — always active; galaxy core and neon signs glow */}
+			<Bloom
+				intensity={1.0 + cityWeight * 0.5}
+				luminanceThreshold={0.6}
+				luminanceSmoothing={0.9}
+				mipmapBlur
+			/>
+
+			{/* Chromatic Aberration — subtle galaxy, stronger city */}
+			<ChromaticAberration
+				offset={caOffset}
+				blendFunction={BlendFunction.NORMAL}
+				radialModulation={false}
+				modulationOffset={0}
+			/>
+
+			{/* Film Grain — always on, very subtle */}
+			<Noise opacity={0.03 + cityWeight * 0.02} />
+
+			{/* Vignette — edges darken in city section */}
+			<Vignette
+				offset={0.2 + cityWeight * 0.2}
+				darkness={0.5 + cityWeight * 0.3}
+				blendFunction={BlendFunction.NORMAL}
+			/>
+		</EffectComposer>
+	);
+}

--- a/app/features/experience/scroll-section.ts
+++ b/app/features/experience/scroll-section.ts
@@ -1,0 +1,29 @@
+/**
+ * scroll-section.ts — scroll section enumeration
+ *
+ * The three discrete camera positions in the portfolio experience.
+ * The camera interpolates between these states driven by scroll progress.
+ *
+ * GALAXY_ANGLED  Section 1 — spiral galaxy seen at ~30° angle (hero view)
+ * GALAXY_TOP     Section 2 — same galaxy from directly above (about view)
+ * CITY           Section 3 — cyberpunk mega-city aerial view (work + contact)
+ */
+
+export const ScrollSection = {
+	GALAXY_ANGLED: 0,
+	GALAXY_TOP: 1,
+	CITY: 2,
+} as const;
+
+export type ScrollSection = (typeof ScrollSection)[keyof typeof ScrollSection];
+
+/**
+ * Normalised scroll offsets at which each section begins.
+ * These are the snap anchor points used by GSAP ScrollTrigger.
+ */
+export const SECTION_OFFSETS = [0, 0.33, 0.66] as const;
+
+/**
+ * Number of discrete scroll sections.
+ */
+export const SECTION_COUNT = 3 as const;


### PR DESCRIPTION
## Summary

The `experience` pod is the root Three.js canvas and the single entry point for all 3D rendering. Every other Phase 3 pod mounts inside it.

### Files

| File | What it does |
|---|---|
| `scroll-section.ts` | `ScrollSection` enum (0=GALAXY_ANGLED, 1=GALAXY_TOP, 2=CITY), `SECTION_OFFSETS`, `SECTION_COUNT` |
| `camera-rig.tsx` | Mounts inside `<Canvas>` — reads `useScroll()` offset, lerps camera position and look-at between 3 keyframes each frame (smooth inertia, no GSAP in render loop) |
| `post-fx.tsx` | `EffectComposer` with Bloom (always on), ChromaticAberration, Noise (film grain), Vignette — all parameterised by `scrollOffset` so effects ramp from subtle (galaxy) to full (city) |
| `experience.tsx` | Fixed-position `<Canvas>`, `ScrollControls` (pages=3), composes `CameraRig` + galaxy/city scene groups + `PostFx`; single-scene approach — galaxy group fades out as city group fades in |
| `mod.ts` | Barrel |

### Architecture decision

Galaxy and city are **one Three.js scene** — opacity/visibility swap driven by scroll progress. This was chosen over remounting separate scenes because: (1) no loading stutter at the transition point, (2) simpler camera continuity, (3) both scenes can share the same post-processing pass.

## Part of

Phase 3 stacked PR chain:
1. `feat/phase-3-01-foundation` — Foundation ✓
2. **→ This PR** — experience pod
3. `feat/phase-3-03-galaxy` — galaxy pod
4. `feat/phase-3-04-city` — city pod
5. `feat/phase-3-05-overlays` — overlay pods
6. `feat/phase-3-06-audio` — audio pod
7. `feat/phase-3-07-integration` — home.tsx wiring