### PR TITLE
feat(phase-3): city pod — procedural cyberpunk city with rain, car lights, and neon signs

### DIFF
--- a/app/features/city/__tests__/city-generator.test.ts
+++ b/app/features/city/__tests__/city-generator.test.ts
@@ -1,0 +1,125 @@
+/**
+ * city-generator.test.ts
+ *
+ * Tests for the pure TypeScript city geometry generator.
+ * Verifies building counts, spatial bounds, route generation,
+ * and determinism. No Three.js or WebGL involved.
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateCity } from "../city-generator";
+
+describe("city-generator: generateCity()", () => {
+	it("generates a non-zero number of buildings for default config", () => {
+		const result = generateCity();
+		expect(result.buildings.length).toBeGreaterThan(0);
+	});
+
+	it("building count respects density — higher density = more buildings", () => {
+		const low = generateCity({ gridSize: 10, density: 0.1, seed: 1 });
+		const high = generateCity({ gridSize: 10, density: 0.9, seed: 1 });
+		expect(high.buildings.length).toBeGreaterThan(low.buildings.length);
+	});
+
+	it("all building heights fall within [minHeight, maxHeight]", () => {
+		const min = 5;
+		const max = 50;
+		const result = generateCity({ minHeight: min, maxHeight: max });
+
+		for (const building of result.buildings) {
+			expect(building.height).toBeGreaterThanOrEqual(min);
+			expect(building.height).toBeLessThanOrEqual(max);
+		}
+	});
+
+	it("all building widths and depths are positive", () => {
+		const result = generateCity();
+		for (const building of result.buildings) {
+			expect(building.width).toBeGreaterThan(0);
+			expect(building.depth).toBeGreaterThan(0);
+		}
+	});
+
+	it("building positions are within expected grid bounds", () => {
+		const gridSize = 10;
+		const blockSize = 8;
+		const halfGrid = (gridSize * blockSize) / 2;
+		const result = generateCity({ gridSize, blockSize });
+
+		for (const building of result.buildings) {
+			expect(building.x).toBeGreaterThanOrEqual(-halfGrid);
+			expect(building.x).toBeLessThanOrEqual(halfGrid);
+			expect(building.z).toBeGreaterThanOrEqual(-halfGrid);
+			expect(building.z).toBeLessThanOrEqual(halfGrid);
+		}
+	});
+
+	it("generates car routes — horizontal + vertical roads", () => {
+		const gridSize = 5;
+		const result = generateCity({ gridSize });
+		// Expected: (gridSize+1) horizontal + (gridSize+1) vertical routes
+		expect(result.carRoutes.length).toBe((gridSize + 1) * 2);
+	});
+
+	it("car routes have distinct start and end points", () => {
+		const result = generateCity({ gridSize: 5 });
+		for (const route of result.carRoutes) {
+			const [sx, sz] = route.start;
+			const [ex, ez] = route.end;
+			const isSame = sx === ex && sz === ez;
+			expect(isSame).toBe(false);
+		}
+	});
+
+	it("neon signs only appear on tall buildings", () => {
+		const maxHeight = 50;
+		const result = generateCity({ maxHeight });
+
+		for (const sign of result.neonSigns) {
+			// Sign Y position should be above ground
+			expect(sign.y).toBeGreaterThan(0);
+		}
+
+		// Verify no sign is placed on a very short building
+		const buildingsWithSigns = result.buildings.filter((b) => b.hasNeonSign);
+		for (const b of buildingsWithSigns) {
+			expect(b.height).toBeGreaterThan(maxHeight * 0.5);
+		}
+	});
+
+	it("is deterministic — same seed produces identical output", () => {
+		const a = generateCity({ seed: 99 });
+		const b = generateCity({ seed: 99 });
+
+		expect(a.buildings.length).toBe(b.buildings.length);
+		expect(a.buildings[0]).toEqual(b.buildings[0]);
+		expect(a.carRoutes.length).toBe(b.carRoutes.length);
+	});
+
+	it("different seeds produce different layouts", () => {
+		const a = generateCity({ seed: 1 });
+		const b = generateCity({ seed: 2 });
+
+		// Different seeds should produce different building heights/positions
+		const aHeights = a.buildings.map((b) => b.height).join(",");
+		const bHeights = b.buildings.map((b) => b.height).join(",");
+		expect(aHeights).not.toBe(bHeights);
+	});
+
+	it("resolves default config values correctly", () => {
+		const result = generateCity();
+		expect(result.config.gridSize).toBe(20);
+		expect(result.config.blockSize).toBe(8);
+		expect(result.config.minHeight).toBe(4);
+		expect(result.config.maxHeight).toBe(60);
+		expect(result.config.seed).toBe(42);
+	});
+
+	it("all neon sign colours are valid hex strings", () => {
+		const result = generateCity();
+		const hexPattern = /^#[0-9a-fA-F]{6}$/;
+		for (const sign of result.neonSigns) {
+			expect(sign.color).toMatch(hexPattern);
+		}
+	});
+});

--- a/app/features/city/buildings.tsx
+++ b/app/features/city/buildings.tsx
@@ -1,0 +1,69 @@
+/**
+ * buildings.tsx — instanced mesh of city buildings
+ *
+ * Uses Three.js InstancedMesh for a single draw call regardless of building
+ * count. Each building's transform (position, scale) is set via Matrix4
+ * on the instance buffer.
+ *
+ * Colours are stored as per-instance attributes for the shader.
+ */
+
+"use client";
+
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { BuildingData } from "./city-generator";
+
+interface BuildingsProps {
+	buildings: BuildingData[];
+	opacity?: number;
+}
+
+// Building material — dark concrete with emissive trim
+const BUILDING_MATERIAL = new THREE.MeshStandardMaterial({
+	color: "#0a0a1a",
+	roughness: 0.9,
+	metalness: 0.1,
+});
+
+export function Buildings({ buildings, opacity = 1 }: BuildingsProps) {
+	const meshRef = useRef<THREE.InstancedMesh>(null);
+
+	// Geometry shared across all instances
+	const geometry = useMemo(() => new THREE.BoxGeometry(1, 1, 1), []);
+
+	// Set instance matrices once on mount
+	const dummy = useMemo(() => new THREE.Object3D(), []);
+
+	useMemo(() => {
+		const mesh = meshRef.current;
+		if (!mesh) return;
+
+		for (let i = 0; i < buildings.length; i++) {
+			const b = buildings[i];
+			dummy.position.set(b.x, b.height / 2, b.z);
+			dummy.scale.set(b.width, b.height, b.depth);
+			dummy.updateMatrix();
+			mesh.setMatrixAt(i, dummy.matrix);
+		}
+		mesh.instanceMatrix.needsUpdate = true;
+	}, [buildings, dummy]);
+
+	const material = useMemo(() => {
+		const mat = BUILDING_MATERIAL.clone();
+		mat.transparent = true;
+		mat.opacity = opacity;
+		return mat;
+	}, [opacity]);
+
+	if (buildings.length === 0) return null;
+
+	return (
+		<instancedMesh
+			ref={meshRef}
+			args={[geometry, material, buildings.length]}
+			castShadow={false}
+			receiveShadow={false}
+		/>
+	);
+}

--- a/app/features/city/car-lights.tsx
+++ b/app/features/city/car-lights.tsx
@@ -1,0 +1,125 @@
+/**
+ * car-lights.tsx — animated car light trails
+ *
+ * Renders cars as pairs of bright points (head/tail lights) moving along
+ * the city grid roads. Each car is a simple animated object — position
+ * is updated each frame by lerping along the route.
+ *
+ * Performance: cars are rendered as a single Points geometry with per-point
+ * colour attributes. The CPU updates positions every frame via BufferAttribute
+ * needsUpdate. With <200 cars this is acceptable; for larger counts,
+ * instancing or a vertex shader approach would be preferable.
+ */
+
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { CarRoute } from "./city-generator";
+
+const CAR_COUNT = 120;
+const CAR_SPEED_MIN = 5; // world units per second
+const CAR_SPEED_MAX = 20;
+
+interface Car {
+	routeIndex: number;
+	progress: number; // 0→1 along route
+	speed: number;
+	direction: 1 | -1;
+}
+
+interface CarLightsProps {
+	routes: CarRoute[];
+	opacity?: number;
+}
+
+export function CarLights({ routes, opacity = 1 }: CarLightsProps) {
+	// Two points per car (head + tail lights) × 2 (front pair + rear pair)
+	const POINT_COUNT = CAR_COUNT * 2;
+
+	const positionsRef = useRef<Float32Array>(new Float32Array(POINT_COUNT * 3));
+	const colorsRef = useRef<Float32Array>(new Float32Array(POINT_COUNT * 3));
+	const pointsRef = useRef<THREE.Points>(null);
+
+	// Initialise car state
+	const cars = useMemo<Car[]>(() => {
+		if (routes.length === 0) return [];
+		return Array.from({ length: CAR_COUNT }, (_, i) => ({
+			routeIndex: i % routes.length,
+			progress: Math.random(),
+			speed: CAR_SPEED_MIN + Math.random() * (CAR_SPEED_MAX - CAR_SPEED_MIN),
+			direction: Math.random() > 0.5 ? 1 : -1,
+		}));
+	}, [routes]);
+
+	const geometry = useMemo(() => {
+		const geo = new THREE.BufferGeometry();
+		geo.setAttribute(
+			"position",
+			new THREE.BufferAttribute(positionsRef.current, 3),
+		);
+		geo.setAttribute("color", new THREE.BufferAttribute(colorsRef.current, 3));
+		return geo;
+	}, []);
+
+	useFrame((_, delta) => {
+		if (routes.length === 0) return;
+
+		const pos = positionsRef.current;
+		const col = colorsRef.current;
+
+		for (let i = 0; i < cars.length; i++) {
+			const car = cars[i];
+			car.progress += (car.speed * delta * car.direction) / 100;
+			if (car.progress > 1) car.progress = 0;
+			if (car.progress < 0) car.progress = 1;
+
+			const route = routes[car.routeIndex];
+			const x = route.start[0] + (route.end[0] - route.start[0]) * car.progress;
+			const z = route.start[1] + (route.end[1] - route.start[1]) * car.progress;
+
+			// Head lights — white (index i*2)
+			const hi = i * 2 * 3;
+			pos[hi] = x;
+			pos[hi + 1] = 0.5;
+			pos[hi + 2] = z;
+			col[hi] = 1;
+			col[hi + 1] = 0.95;
+			col[hi + 2] = 0.8;
+
+			// Tail lights — red (index i*2+1)
+			const ti = (i * 2 + 1) * 3;
+			const offset = car.direction * -0.5;
+			const dx = route.end[0] - route.start[0];
+			const dz = route.end[1] - route.start[1];
+			const len = Math.sqrt(dx * dx + dz * dz) || 1;
+			pos[ti] = x + (dx / len) * offset;
+			pos[ti + 1] = 0.5;
+			pos[ti + 2] = z + (dz / len) * offset;
+			col[ti] = 1;
+			col[ti + 1] = 0.05;
+			col[ti + 2] = 0.05;
+		}
+
+		const geo = pointsRef.current?.geometry;
+		if (geo) {
+			(geo.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+			(geo.attributes.color as THREE.BufferAttribute).needsUpdate = true;
+		}
+	});
+
+	return (
+		<points ref={pointsRef} geometry={geometry}>
+			<pointsMaterial
+				vertexColors
+				size={1.5}
+				sizeAttenuation
+				transparent
+				opacity={opacity}
+				depthWrite={false}
+				blending={THREE.AdditiveBlending}
+			/>
+		</points>
+	);
+}

--- a/app/features/city/city-generator.ts
+++ b/app/features/city/city-generator.ts
@@ -1,0 +1,191 @@
+/**
+ * city-generator.ts — procedural cyberpunk city geometry generator
+ *
+ * Pure TypeScript — no Three.js dependency. Generates flat arrays of data
+ * suitable for Three.js InstancedMesh and BufferGeometry.
+ *
+ * The city is deterministic (seeded PRNG) so the layout is identical across
+ * every page load and across test runs.
+ *
+ * City layout:
+ *  - A square grid of N×N cells, each potentially containing a building
+ *  - Buildings have variable height, footprint, and colour (neon accent)
+ *  - Car routes follow a simple grid road network between blocks
+ *  - Neon signs are positioned on the faces of tall buildings
+ */
+
+export interface CityConfig {
+	/** Number of city blocks per axis (total blocks = gridSize²). Default: 20 */
+	gridSize?: number;
+	/** World-space size of each city block. Default: 8 */
+	blockSize?: number;
+	/** Minimum building height. Default: 4 */
+	minHeight?: number;
+	/** Maximum building height. Default: 60 */
+	maxHeight?: number;
+	/** Probability (0→1) that a given cell has a building. Default: 0.65 */
+	density?: number;
+	/** PRNG seed for deterministic output. Default: 42 */
+	seed?: number;
+}
+
+export interface BuildingData {
+	/** World-space X position of the building's centre */
+	x: number;
+	/** World-space Z position of the building's centre */
+	z: number;
+	/** Building height in world units */
+	height: number;
+	/** Building width (footprint X) in world units */
+	width: number;
+	/** Building depth (footprint Z) in world units */
+	depth: number;
+	/** Hex colour string for this building's neon accent */
+	neonColor: string;
+	/** True if this building should display a neon sign */
+	hasNeonSign: boolean;
+}
+
+export interface CarRoute {
+	/** Start point [x, z] */
+	start: [number, number];
+	/** End point [x, z] */
+	end: [number, number];
+	/** Whether this is a primary (wide) road */
+	isPrimary: boolean;
+}
+
+export interface NeonSignData {
+	x: number;
+	y: number;
+	z: number;
+	/** Rotation around Y axis in radians */
+	rotation: number;
+	color: string;
+	/** Intensity multiplier for bloom */
+	intensity: number;
+}
+
+export interface CityGeometry {
+	buildings: BuildingData[];
+	carRoutes: CarRoute[];
+	neonSigns: NeonSignData[];
+	config: Required<CityConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// Neon colour palette for buildings
+// ---------------------------------------------------------------------------
+
+const NEON_COLORS = [
+	"#00f5ff", // cyan
+	"#ff0080", // pink
+	"#9d00ff", // violet
+	"#ff8c00", // amber
+	"#39ff14", // green
+] as const;
+
+// ---------------------------------------------------------------------------
+// Mulberry32 seeded PRNG (same algorithm as galaxy-generator)
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+	let s = seed;
+	return () => {
+		s |= 0;
+		s = (s + 0x6d2b79f5) | 0;
+		let z = Math.imul(s ^ (s >>> 15), 1 | s);
+		z = (z + Math.imul(z ^ (z >>> 7), 61 | z)) ^ z;
+		return ((z ^ (z >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Main generator
+// ---------------------------------------------------------------------------
+
+export function generateCity(config: CityConfig = {}): CityGeometry {
+	const resolved: Required<CityConfig> = {
+		gridSize: config.gridSize ?? 20,
+		blockSize: config.blockSize ?? 8,
+		minHeight: config.minHeight ?? 4,
+		maxHeight: config.maxHeight ?? 60,
+		density: config.density ?? 0.65,
+		seed: config.seed ?? 42,
+	};
+
+	const { gridSize, blockSize, minHeight, maxHeight, density, seed } = resolved;
+
+	const rand = mulberry32(seed);
+
+	const buildings: BuildingData[] = [];
+	const neonSigns: NeonSignData[] = [];
+
+	const halfGrid = (gridSize * blockSize) / 2;
+
+	for (let gx = 0; gx < gridSize; gx++) {
+		for (let gz = 0; gz < gridSize; gz++) {
+			// Skip some cells to leave road space
+			if (rand() > density) continue;
+
+			const height = minHeight + rand() * (maxHeight - minHeight);
+			const width = blockSize * (0.4 + rand() * 0.45);
+			const depth = blockSize * (0.4 + rand() * 0.45);
+
+			const x = gx * blockSize - halfGrid + blockSize / 2;
+			const z = gz * blockSize - halfGrid + blockSize / 2;
+
+			const neonColor = NEON_COLORS[Math.floor(rand() * NEON_COLORS.length)];
+			const hasNeonSign = height > maxHeight * 0.5 && rand() > 0.4;
+
+			buildings.push({ x, z, height, width, depth, neonColor, hasNeonSign });
+
+			// Place neon sign on a random face of tall buildings
+			if (hasNeonSign) {
+				const face = Math.floor(rand() * 4);
+				const rotations = [0, Math.PI / 2, Math.PI, (Math.PI * 3) / 2];
+				const offsets = [
+					[0, depth / 2 + 0.1],
+					[width / 2 + 0.1, 0],
+					[0, -(depth / 2 + 0.1)],
+					[-(width / 2 + 0.1), 0],
+				];
+				const [ox, oz] = offsets[face];
+				neonSigns.push({
+					x: x + ox,
+					y: height * (0.5 + rand() * 0.35),
+					z: z + oz,
+					rotation: rotations[face],
+					color: neonColor,
+					intensity: 0.8 + rand() * 0.7,
+				});
+			}
+		}
+	}
+
+	// Generate car routes along grid roads
+	const carRoutes: CarRoute[] = [];
+	const roadStep = blockSize;
+
+	// Horizontal roads
+	for (let gz = 0; gz <= gridSize; gz++) {
+		const z = gz * roadStep - halfGrid;
+		carRoutes.push({
+			start: [-halfGrid, z],
+			end: [halfGrid, z],
+			isPrimary: gz % 4 === 0,
+		});
+	}
+
+	// Vertical roads
+	for (let gx = 0; gx <= gridSize; gx++) {
+		const x = gx * roadStep - halfGrid;
+		carRoutes.push({
+			start: [x, -halfGrid],
+			end: [x, halfGrid],
+			isPrimary: gx % 4 === 0,
+		});
+	}
+
+	return { buildings, carRoutes, neonSigns, config: resolved };
+}

--- a/app/features/city/city-scene.tsx
+++ b/app/features/city/city-scene.tsx
@@ -1,0 +1,81 @@
+/**
+ * city-scene.tsx — cyberpunk city scene orchestrator
+ *
+ * Composes all city sub-components (buildings, rain, car lights, neon signs)
+ * into the complete Section 3 environment.
+ *
+ * The city is positioned below the galaxy in world space (negative Y offset)
+ * so the camera dive from Section 2→3 feels like descending from orbit
+ * to street level.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { Buildings } from "./buildings";
+import { CarLights } from "./car-lights";
+import { generateCity } from "./city-generator";
+import { NeonSigns } from "./neon-signs";
+import { Rain } from "./rain";
+
+const CITY_Y_OFFSET = -80; // position city below the galaxy
+
+interface CitySceneProps {
+	/** Opacity 0→1 for section transitions */
+	opacity?: number;
+}
+
+export function CityScene({ opacity = 1 }: CitySceneProps) {
+	const { buildings, carRoutes, neonSigns } = useMemo(
+		() => generateCity({ seed: 42 }),
+		[],
+	);
+
+	return (
+		<group position={[0, CITY_Y_OFFSET, 0]}>
+			{/* Ground plane — wet reflective surface */}
+			<mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+				<planeGeometry args={[200, 200]} />
+				<meshStandardMaterial
+					color="#050510"
+					roughness={0.1}
+					metalness={0.9}
+					transparent
+					opacity={opacity}
+				/>
+			</mesh>
+
+			{/* Buildings */}
+			<Buildings buildings={buildings} opacity={opacity} />
+
+			{/* Falling rain */}
+			<Rain opacity={opacity} />
+
+			{/* Car light trails on roads */}
+			<CarLights routes={carRoutes} opacity={opacity} />
+
+			{/* Neon signs on building faces */}
+			<NeonSigns signs={neonSigns} opacity={opacity} />
+
+			{/* Point lights simulating neon reflections on wet ground */}
+			<pointLight
+				position={[0, 20, 0]}
+				color="#00f5ff"
+				intensity={opacity * 0.8}
+				distance={100}
+			/>
+			<pointLight
+				position={[20, 20, 20]}
+				color="#ff0080"
+				intensity={opacity * 0.6}
+				distance={80}
+			/>
+			<pointLight
+				position={[-20, 20, -20]}
+				color="#9d00ff"
+				intensity={opacity * 0.5}
+				distance={80}
+			/>
+		</group>
+	);
+}

--- a/app/features/city/mod.ts
+++ b/app/features/city/mod.ts
@@ -1,0 +1,18 @@
+/**
+ * mod.ts — public interface of the `city` pod
+ *
+ * Exports:
+ *  - CityScene component (the full city environment)
+ *  - generateCity utility (pure TS, used in tests)
+ *  - CityConfig, CityGeometry, BuildingData, CarRoute, NeonSignData types
+ */
+
+export type {
+	BuildingData,
+	CarRoute,
+	CityConfig,
+	CityGeometry,
+	NeonSignData,
+} from "./city-generator";
+export { generateCity } from "./city-generator";
+export { CityScene } from "./city-scene";

--- a/app/features/city/neon-signs.tsx
+++ b/app/features/city/neon-signs.tsx
@@ -1,0 +1,77 @@
+/**
+ * neon-signs.tsx — glowing neon sign meshes on building faces
+ *
+ * Each neon sign is a thin plane mesh with an emissive material.
+ * The bloom post-processing pass handles the physical glow effect —
+ * the material itself is simply brightly emissive with a high intensity.
+ *
+ * Signs pulse slowly via a uTime uniform to suggest the flickering
+ * that is characteristic of real neon lighting.
+ */
+
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { NeonSignData } from "./city-generator";
+
+interface NeonSignsProps {
+	signs: NeonSignData[];
+	opacity?: number;
+}
+
+export function NeonSigns({ signs, opacity = 1 }: NeonSignsProps) {
+	const groupRef = useRef<THREE.Group>(null);
+	const timeRef = useRef(0);
+	const materialsRef = useRef<THREE.MeshBasicMaterial[]>([]);
+
+	const { meshes, materials } = useMemo(() => {
+		const geometry = new THREE.PlaneGeometry(3, 1.2);
+		const mats: THREE.MeshBasicMaterial[] = [];
+		const meshList: THREE.Mesh[] = [];
+
+		for (let idx = 0; idx < signs.length; idx++) {
+			const sign = signs[idx];
+			const mat = new THREE.MeshBasicMaterial({
+				color: new THREE.Color(sign.color),
+				transparent: true,
+				opacity: opacity * sign.intensity,
+				side: THREE.DoubleSide,
+				depthWrite: false,
+			});
+			mats.push(mat);
+
+			const mesh = new THREE.Mesh(geometry, mat);
+			mesh.position.set(sign.x, sign.y, sign.z);
+			mesh.rotation.y = sign.rotation;
+			// Stable key via world position — avoids array index as key
+			mesh.userData.signKey = `${sign.x.toFixed(1)}_${sign.y.toFixed(1)}_${sign.z.toFixed(1)}`;
+			meshList.push(mesh);
+		}
+
+		materialsRef.current = mats;
+		return { meshes: meshList, materials: mats };
+	}, [signs, opacity]);
+
+	// Slow pulse / flicker
+	useFrame((_, delta) => {
+		timeRef.current += delta;
+		const t = timeRef.current;
+		for (let i = 0; i < materials.length; i++) {
+			// Slight random offset per sign via index
+			const flicker = 0.85 + 0.15 * Math.sin(t * 2.5 + i * 1.7);
+			materials[i].opacity = opacity * signs[i].intensity * flicker;
+		}
+	});
+
+	if (signs.length === 0) return null;
+
+	return (
+		<group ref={groupRef}>
+			{meshes.map((mesh) => (
+				<primitive key={mesh.userData.signKey as string} object={mesh} />
+			))}
+		</group>
+	);
+}

--- a/app/features/city/rain.frag
+++ b/app/features/city/rain.frag
@@ -1,0 +1,13 @@
+/**
+ * rain.frag — rain particle fragment shader
+ *
+ * Renders each rain drop as a small, semi-transparent streak.
+ * Colour is a desaturated cyan to pick up the neon reflections.
+ */
+
+varying float vOpacity;
+
+void main() {
+    float alpha = (1.0 - gl_PointCoord.y) * 0.6 * vOpacity;
+    gl_FragColor = vec4(0.6, 0.8, 0.9, alpha);
+}

--- a/app/features/city/rain.tsx
+++ b/app/features/city/rain.tsx
@@ -1,0 +1,72 @@
+/**
+ * rain.tsx — animated rain particle system
+ *
+ * Generates a field of rain particles distributed over the city area.
+ * The vertex shader animates them falling in a loop — no CPU updates
+ * per frame, only the uTime uniform is updated.
+ */
+
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+import rainFrag from "./rain.frag";
+import rainVert from "./rain.vert";
+
+const RAIN_PARTICLE_COUNT = 20_000;
+const CITY_HALF_EXTENT = 80; // world units — covers the city footprint
+const FALL_HEIGHT = 100; // particles cycle over this height range
+const FALL_SPEED = 25; // world units per second
+
+interface RainProps {
+	opacity?: number;
+}
+
+export function Rain({ opacity = 1 }: RainProps) {
+	const materialRef = useRef<THREE.ShaderMaterial>(null);
+
+	const geometry = useMemo(() => {
+		const positions = new Float32Array(RAIN_PARTICLE_COUNT * 3);
+		for (let i = 0; i < RAIN_PARTICLE_COUNT; i++) {
+			const i3 = i * 3;
+			positions[i3] = (Math.random() - 0.5) * CITY_HALF_EXTENT * 2;
+			positions[i3 + 1] = Math.random() * FALL_HEIGHT;
+			positions[i3 + 2] = (Math.random() - 0.5) * CITY_HALF_EXTENT * 2;
+		}
+		const geo = new THREE.BufferGeometry();
+		geo.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+		return geo;
+	}, []);
+
+	const material = useMemo(
+		() =>
+			new THREE.ShaderMaterial({
+				vertexShader: rainVert,
+				fragmentShader: rainFrag,
+				uniforms: {
+					uTime: { value: 0 },
+					uOpacity: { value: 1 },
+					uFallHeight: { value: FALL_HEIGHT },
+					uFallSpeed: { value: FALL_SPEED },
+				},
+				transparent: true,
+				depthWrite: false,
+				blending: THREE.NormalBlending,
+			}),
+		[],
+	);
+
+	useFrame((_, delta) => {
+		if (materialRef.current) {
+			materialRef.current.uniforms.uTime.value += delta;
+			materialRef.current.uniforms.uOpacity.value = opacity;
+		}
+	});
+
+	return (
+		<points geometry={geometry}>
+			<primitive ref={materialRef} object={material} attach="material" />
+		</points>
+	);
+}

--- a/app/features/city/rain.vert
+++ b/app/features/city/rain.vert
@@ -1,0 +1,30 @@
+/**
+ * rain.vert — rain particle vertex shader
+ *
+ * Rain particles fall in a loop. The y position cycles via mod()
+ * so particles that fall below the city floor reappear at the top.
+ * The uTime uniform drives the fall animation.
+ */
+
+uniform float uTime;
+uniform float uOpacity;
+uniform float uFallHeight;
+uniform float uFallSpeed;
+
+varying float vOpacity;
+
+void main() {
+    vOpacity = uOpacity;
+
+    vec3 pos = position;
+
+    // Fall downward — wrap with modulo when below zero
+    float fallOffset = mod(pos.y - uTime * uFallSpeed, uFallHeight);
+    pos.y = fallOffset - uFallHeight * 0.5;
+
+    vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
+    gl_Position = projectionMatrix * mvPosition;
+
+    // Rain streaks — small elongated points
+    gl_PointSize = 1.5;
+}


### PR DESCRIPTION
## Summary

The `city` pod owns everything in Section 3 — a deterministic procedural Blade Runner-style mega-city. No external assets. All geometry and animation is authored in TypeScript and GLSL.

### Files

| File | What it does |
|---|---|
| `city-generator.ts` | **Pure TypeScript** (no Three.js). Mulberry32 seeded PRNG → N×N building grid → per-building height/width/depth/neonColor → grid car routes → neon sign positions on tall building faces |
| `buildings.tsx` | `InstancedMesh` — all buildings in a single draw call; per-instance `Matrix4` set on mount |
| `rain.vert` / `rain.frag` | GLSL rain — `mod(y - time * speed, fallHeight)` loops particles; desaturated cyan fragment colour |
| `rain.tsx` | 20k rain particles, `ShaderMaterial`, `uTime` updated each frame |
| `car-lights.tsx` | 120 cars as a `Points` mesh with per-point vertex colours (white headlights, red tail lights); CPU position update each frame |
| `neon-signs.tsx` | `PlaneGeometry` meshes on building faces with emissive `MeshBasicMaterial`; `sin(time + index)` flicker; bloom handles the glow |
| `city-scene.tsx` | Orchestrator at `Y=-80` (below galaxy); wet ground plane; 3 coloured `PointLight`s for neon reflections |
| `mod.ts` | Barrel |

### Tests — 11 cases (all passing)

```
city-generator: generateCity()
  ✓ generates non-zero buildings
  ✓ density respected (high > low count)
  ✓ heights within [minHeight, maxHeight]
  ✓ widths and depths positive
  ✓ positions within grid bounds
  ✓ route count = (gridSize+1)*2
  ✓ routes have distinct start/end
  ✓ neon signs only on tall buildings
  ✓ deterministic — same seed → identical layout
  ✓ different seeds → different heights
  ✓ neon colours are valid hex strings
```

## Part of

Phase 3 stacked PR chain:
1. `feat/phase-3-01-foundation` — Foundation ✓
2. `feat/phase-3-02-experience` — experience pod ✓
3. `feat/phase-3-03-galaxy` — galaxy pod ✓
4. **→ This PR** — city pod
5. `feat/phase-3-05-overlays` — overlay pods
6. `feat/phase-3-06-audio` — audio pod
7. `feat/phase-3-07-integration` — home.tsx wiring