### PR TITLE
feat(phase-3): overlay pods — hero, about, work, and contact HTML layers

### DIFF
--- a/app/features/about/__tests__/about-overlay.test.tsx
+++ b/app/features/about/__tests__/about-overlay.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+/**
+ * about-overlay.test.tsx
+ *
+ * Tests for the AboutOverlay component.
+ * Verifies bio rendering, skills list, photo, and graceful fallbacks
+ * for null/empty optional fields.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	mockAbout,
+	mockAboutMinimal,
+	mockSiteConfig,
+} from "~/test/fixtures/cms.fixtures";
+import { AboutOverlay } from "../about-overlay";
+
+describe("AboutOverlay: renders CMS data correctly", () => {
+	it("renders the about section title from siteConfig", () => {
+		render(
+			<AboutOverlay about={mockAbout} siteConfig={mockSiteConfig} visible />,
+		);
+		expect(
+			screen.getByText(mockSiteConfig.sectionTitles.about),
+		).toBeInTheDocument();
+	});
+
+	it("renders skills as a list when skills are present", () => {
+		const about = { ...mockAbout, skills: ["React", "TypeScript", "Three.js"] };
+		render(<AboutOverlay about={about} siteConfig={mockSiteConfig} visible />);
+		const list = screen.getByRole("list", { name: /skills and technologies/i });
+		expect(list).toBeInTheDocument();
+		expect(screen.getByText("React")).toBeInTheDocument();
+		expect(screen.getByText("TypeScript")).toBeInTheDocument();
+		expect(screen.getByText("Three.js")).toBeInTheDocument();
+	});
+
+	it("does not render skills section when skills array is empty", () => {
+		render(
+			<AboutOverlay
+				about={mockAboutMinimal}
+				siteConfig={mockSiteConfig}
+				visible
+			/>,
+		);
+		expect(
+			screen.queryByRole("list", { name: /skills/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders 'Bio coming soon' when bio is null", () => {
+		render(
+			<AboutOverlay
+				about={mockAboutMinimal}
+				siteConfig={mockSiteConfig}
+				visible
+			/>,
+		);
+		expect(screen.getByText(/bio coming soon/i)).toBeInTheDocument();
+	});
+
+	it("does not render photo when photo is null", () => {
+		render(
+			<AboutOverlay
+				about={mockAboutMinimal}
+				siteConfig={mockSiteConfig}
+				visible
+			/>,
+		);
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
+
+	it("renders photo when present", () => {
+		const aboutWithPhoto = {
+			...mockAbout,
+			photo: {
+				url: "https://example.com/photo.jpg",
+				width: 400,
+				height: 400,
+				alt: "Profile photo",
+				sizes: { thumbnail: null, og: null },
+			},
+		};
+		render(
+			<AboutOverlay
+				about={aboutWithPhoto}
+				siteConfig={mockSiteConfig}
+				visible
+			/>,
+		);
+		const img = screen.getByRole("img");
+		expect(img).toHaveAttribute("alt", "Profile photo");
+	});
+
+	it("section has accessible landmark label", () => {
+		render(
+			<AboutOverlay about={mockAbout} siteConfig={mockSiteConfig} visible />,
+		);
+		expect(
+			screen.getByRole("region", { name: /about section/i }),
+		).toBeInTheDocument();
+	});
+
+	it("applies opacity-0 class when not visible (desktop mode)", () => {
+		const { container } = render(
+			<AboutOverlay
+				about={mockAbout}
+				siteConfig={mockSiteConfig}
+				visible={false}
+				isMobile={false}
+			/>,
+		);
+		// The section should have the opacity-0 class when not visible
+		const section = container.querySelector("section");
+		expect(section?.className).toContain("opacity-0");
+	});
+});

--- a/app/features/about/about-overlay.tsx
+++ b/app/features/about/about-overlay.tsx
@@ -1,0 +1,129 @@
+/**
+ * about-overlay.tsx — HTML content overlay for Section 2 (Galaxy Top-Down view)
+ *
+ * Displays the portfolio owner's bio, skills, and an optional photo.
+ * The overlay fades in as the camera locks to the top-down position.
+ *
+ * The bio field is a Lexical rich-text document. For Phase 3, it is rendered
+ * as plain text paragraphs extracted from the Lexical AST. A full Lexical
+ * renderer can be wired in Phase 4 if needed.
+ *
+ * Accessibility:
+ *  - Skills are rendered as a visually styled list with proper list semantics.
+ *  - The photo has descriptive alt text from the CMS.
+ */
+
+import type { About, SiteConfig } from "~/services/cms/mod";
+
+export interface AboutOverlayProps {
+	about: About;
+	siteConfig: SiteConfig;
+	/** Opacity 0→1 driven by scroll position */
+	visible?: boolean;
+	isMobile?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal Lexical text extractor
+// ---------------------------------------------------------------------------
+
+interface LexicalNode {
+	type: string;
+	text?: string;
+	children?: LexicalNode[];
+}
+
+function extractText(node: unknown): string {
+	if (!node || typeof node !== "object") return "";
+	const n = node as LexicalNode;
+	if (n.type === "text" && typeof n.text === "string") return n.text;
+	if (Array.isArray(n.children)) {
+		return n.children
+			.map(extractText)
+			.join(n.type === "paragraph" ? "\n" : " ");
+	}
+	const root = (n as { root?: LexicalNode }).root;
+	if (root) return extractText(root);
+	return "";
+}
+
+export function AboutOverlay({
+	about,
+	siteConfig,
+	visible = true,
+	isMobile = false,
+}: AboutOverlayProps) {
+	const bioText = about.bio ? extractText(about.bio) : null;
+	const sectionTitle = siteConfig.sectionTitles.about;
+
+	const wrapperClass = isMobile
+		? "px-6 py-16 max-w-2xl mx-auto"
+		: [
+				"pointer-events-none fixed inset-0 z-10 flex items-center justify-start",
+				"pl-12 lg:pl-24",
+				"transition-opacity duration-700",
+				visible ? "opacity-100" : "opacity-0",
+			].join(" ");
+
+	return (
+		<section className={wrapperClass} aria-label="About section">
+			<div className="max-w-xl pointer-events-auto">
+				{/* Section title */}
+				<p className="font-display text-xs tracking-[0.3em] uppercase text-[var(--color-neon-cyan)] mb-4">
+					{sectionTitle}
+				</p>
+
+				{/* Bio */}
+				{bioText ? (
+					<div className="space-y-4">
+						{bioText.split("\n").map((paragraph) => (
+							<p
+								key={paragraph.slice(0, 40)}
+								className="font-sans text-base lg:text-lg leading-relaxed text-[var(--color-text-primary)]"
+							>
+								{paragraph}
+							</p>
+						))}
+					</div>
+				) : (
+					<p className="font-sans text-base text-[var(--color-text-muted)]">
+						Bio coming soon.
+					</p>
+				)}
+
+				{/* Skills */}
+				{about.skills.length > 0 && (
+					<div className="mt-8">
+						<p className="font-sans text-xs tracking-[0.2em] uppercase text-[var(--color-text-muted)] mb-3">
+							Technologies
+						</p>
+						<ul
+							className="flex flex-wrap gap-2"
+							aria-label="Skills and technologies"
+						>
+							{about.skills.map((skill) => (
+								<li
+									key={skill}
+									className="px-3 py-1 text-xs font-sans rounded-full border border-[var(--color-border)] text-[var(--color-text-muted)] bg-[var(--color-surface-1)]"
+								>
+									{skill}
+								</li>
+							))}
+						</ul>
+					</div>
+				)}
+
+				{/* Photo */}
+				{about.photo && (
+					<img
+						src={about.photo.sizes?.thumbnail?.url ?? about.photo.url}
+						alt={about.photo.alt ?? "Portrait"}
+						width={about.photo.sizes?.thumbnail?.width ?? 120}
+						height={about.photo.sizes?.thumbnail?.height ?? 120}
+						className="mt-6 rounded-full w-24 h-24 object-cover border-2 border-[var(--color-neon-cyan)]"
+					/>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/app/features/about/mod.ts
+++ b/app/features/about/mod.ts
@@ -1,0 +1,10 @@
+/**
+ * mod.ts — public interface of the `about` pod
+ *
+ * Exports:
+ *  - AboutOverlay component
+ *  - AboutOverlayProps type
+ */
+
+export type { AboutOverlayProps } from "./about-overlay";
+export { AboutOverlay } from "./about-overlay";

--- a/app/features/contact/__tests__/contact-overlay.test.tsx
+++ b/app/features/contact/__tests__/contact-overlay.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+/**
+ * contact-overlay.test.tsx
+ *
+ * Tests for the ContactOverlay component.
+ * Verifies email link, social links, CTA text, and fallbacks.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	mockContact,
+	mockContactMinimal,
+	mockSiteConfig,
+} from "~/test/fixtures/cms.fixtures";
+import { ContactOverlay } from "../contact-overlay";
+
+// Use a simple siteConfig and contact for tests that assert on text content
+// — zocker generates long multiline strings that getByText can't reliably match.
+const simpleSiteConfig = {
+	...mockSiteConfig,
+	sectionTitles: {
+		hero: "Hello, Universe",
+		about: "About",
+		work: "Work",
+		contact: "Contact",
+	},
+};
+
+const simpleContact = {
+	...mockContact,
+	email: "hello@harihoudini.dev",
+	ctaText: "Let's work together",
+	socials: [],
+};
+
+describe("ContactOverlay: renders contact data correctly", () => {
+	it("renders the contact section title from siteConfig", () => {
+		render(
+			<ContactOverlay
+				contact={simpleContact}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(screen.getByText("Contact")).toBeInTheDocument();
+	});
+
+	it("renders the CTA text", () => {
+		render(
+			<ContactOverlay
+				contact={simpleContact}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(screen.getByText("Let's work together")).toBeInTheDocument();
+	});
+
+	it("renders the email as a selectable mailto link", () => {
+		render(
+			<ContactOverlay
+				contact={simpleContact}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		const emailLink = screen.getByRole("link", {
+			name: /send email to hello@harihoudini\.dev/i,
+		});
+		expect(emailLink).toHaveAttribute("href", "mailto:hello@harihoudini.dev");
+		// Email should be visible text — not obfuscated
+		expect(emailLink).toHaveTextContent("hello@harihoudini.dev");
+	});
+
+	it("renders social links as a nav when socials are present", () => {
+		const contact = {
+			...simpleContact,
+			socials: [
+				{ platform: "github", url: "https://github.com/user", label: "GitHub" },
+				{
+					platform: "linkedin",
+					url: "https://linkedin.com/in/user",
+					label: "LinkedIn",
+				},
+			],
+		};
+		render(
+			<ContactOverlay
+				contact={contact}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		const nav = screen.getByRole("navigation", { name: /social media links/i });
+		expect(nav).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /github profile/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /linkedin profile/i }),
+		).toBeInTheDocument();
+	});
+
+	it("does not render social nav when socials array is empty", () => {
+		render(
+			<ContactOverlay
+				contact={mockContactMinimal}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(
+			screen.queryByRole("navigation", { name: /social/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("social links open in new tab with noopener noreferrer", () => {
+		const contact = {
+			...simpleContact,
+			socials: [
+				{ platform: "github", url: "https://github.com/user", label: "GitHub" },
+			],
+		};
+		render(
+			<ContactOverlay
+				contact={contact}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		const link = screen.getByRole("link", { name: /github profile/i });
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("section has accessible landmark label", () => {
+		render(
+			<ContactOverlay
+				contact={simpleContact}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(
+			screen.getByRole("region", { name: /contact section/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/app/features/contact/contact-overlay.tsx
+++ b/app/features/contact/contact-overlay.tsx
@@ -1,0 +1,100 @@
+/**
+ * contact-overlay.tsx — HTML content overlay for the contact section
+ *
+ * Appears within Section 3 (city view), below the project list.
+ * Displays the portfolio owner's email, social links, and a CTA.
+ *
+ * Accessibility:
+ *  - Email is selectable plain text — never an image or obfuscated string.
+ *  - Social links use visually-hidden labels for screen readers.
+ *  - The section has a clear landmark heading.
+ */
+
+import type { Contact, SiteConfig } from "~/services/cms/mod";
+
+export interface ContactOverlayProps {
+	contact: Contact;
+	siteConfig: SiteConfig;
+	visible?: boolean;
+	isMobile?: boolean;
+}
+
+const PLATFORM_LABELS: Record<string, string> = {
+	github: "GitHub",
+	twitter: "Twitter / X",
+	x: "Twitter / X",
+	linkedin: "LinkedIn",
+	instagram: "Instagram",
+	youtube: "YouTube",
+	dribbble: "Dribbble",
+	behance: "Behance",
+};
+
+export function ContactOverlay({
+	contact,
+	siteConfig,
+	visible = true,
+	isMobile = false,
+}: ContactOverlayProps) {
+	const { email, ctaText, socials } = contact;
+	const sectionTitle = siteConfig.sectionTitles.contact;
+
+	const wrapperClass = isMobile
+		? "px-6 py-16 border-t border-[var(--color-border)]"
+		: [
+				"pointer-events-none fixed bottom-0 left-0 right-0 z-10",
+				"flex flex-col items-center text-center pb-12 px-6",
+				"transition-opacity duration-700",
+				visible ? "opacity-100" : "opacity-0",
+			].join(" ");
+
+	return (
+		<section className={wrapperClass} aria-label="Contact section">
+			<div className="pointer-events-auto">
+				{/* Section heading */}
+				<p className="font-display text-xs tracking-[0.3em] uppercase text-[var(--color-neon-violet)] mb-4">
+					{sectionTitle}
+				</p>
+
+				{/* CTA text */}
+				<p className="font-display text-2xl lg:text-3xl font-light text-[var(--color-text-primary)] mb-6">
+					{ctaText}
+				</p>
+
+				{/* Email — plain selectable text */}
+				<a
+					href={`mailto:${email}`}
+					className="font-sans text-base lg:text-lg text-[var(--color-neon-cyan)] hover:underline"
+					aria-label={`Send email to ${email}`}
+				>
+					{email}
+				</a>
+
+				{/* Social links */}
+				{socials.length > 0 && (
+					<nav
+						className="mt-6 flex gap-4 justify-center"
+						aria-label="Social media links"
+					>
+						{socials.map((social) => {
+							const label =
+								PLATFORM_LABELS[social.platform.toLowerCase()] ?? social.label;
+							return (
+								<a
+									key={social.platform}
+									href={social.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="font-sans text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+									aria-label={`Visit ${label} profile`}
+								>
+									{label}
+								</a>
+							);
+						})}
+					</nav>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/app/features/contact/mod.ts
+++ b/app/features/contact/mod.ts
@@ -1,0 +1,10 @@
+/**
+ * mod.ts — public interface of the `contact` pod
+ *
+ * Exports:
+ *  - ContactOverlay component
+ *  - ContactOverlayProps type
+ */
+
+export type { ContactOverlayProps } from "./contact-overlay";
+export { ContactOverlay } from "./contact-overlay";

--- a/app/features/hero/__tests__/hero-overlay.test.tsx
+++ b/app/features/hero/__tests__/hero-overlay.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+/**
+ * hero-overlay.test.tsx
+ *
+ * Tests for the HeroOverlay component.
+ * Verifies that CMS data is correctly rendered with accessible markup.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	mockSiteConfig,
+	mockSiteConfigMinimal,
+} from "~/test/fixtures/cms.fixtures";
+import { HeroOverlay } from "../hero-overlay";
+
+describe("HeroOverlay: renders CMS data correctly", () => {
+	it("renders the owner name as an h1 heading", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfig} introComplete />);
+		const heading = screen.getByRole("heading", { level: 1 });
+		expect(heading).toHaveTextContent(mockSiteConfig.name);
+	});
+
+	it("renders the tagline", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfig} introComplete />);
+		expect(screen.getByText(mockSiteConfig.tagline)).toBeInTheDocument();
+	});
+
+	it("renders the subtitle when present", () => {
+		const config = {
+			...mockSiteConfig,
+			subtitle: "A subtitle line",
+		};
+		render(<HeroOverlay siteConfig={config} introComplete />);
+		expect(screen.getByText("A subtitle line")).toBeInTheDocument();
+	});
+
+	it("does not render subtitle when null", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfigMinimal} introComplete />);
+		// mockSiteConfigMinimal has subtitle: null
+		// Confirm the literal string "null" is not rendered in the DOM
+		expect(screen.queryByText("null")).not.toBeInTheDocument();
+	});
+
+	it("renders scroll prompt on desktop (non-mobile)", () => {
+		render(
+			<HeroOverlay
+				siteConfig={mockSiteConfig}
+				introComplete
+				isMobile={false}
+			/>,
+		);
+		expect(
+			screen.getByRole("status", { name: /scroll to explore/i }),
+		).toBeInTheDocument();
+	});
+
+	it("does not render scroll prompt on mobile", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfig} introComplete isMobile />);
+		expect(
+			screen.queryByRole("status", { name: /scroll to explore/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("name heading is opacity-0 when introComplete is false", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfig} introComplete={false} />);
+		const heading = screen.getByRole("heading", { level: 1 });
+		expect(heading.className).toContain("opacity-0");
+	});
+
+	it("name heading is opacity-100 when introComplete is true", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfig} introComplete />);
+		const heading = screen.getByRole("heading", { level: 1 });
+		expect(heading.className).toContain("opacity-100");
+	});
+
+	it("section has accessible landmark label", () => {
+		render(<HeroOverlay siteConfig={mockSiteConfig} introComplete />);
+		expect(
+			screen.getByRole("region", { name: /portfolio introduction/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/app/features/hero/hero-overlay.tsx
+++ b/app/features/hero/hero-overlay.tsx
@@ -1,0 +1,115 @@
+/**
+ * hero-overlay.tsx — HTML content overlay for Section 1 (Galaxy Angled view)
+ *
+ * Displays the portfolio owner's name, tagline, subtitle, and a scroll prompt.
+ * This overlay is positioned as a fixed layer above the Three.js canvas.
+ *
+ * Accessibility:
+ *  - The name is an <h1> — correct document heading hierarchy.
+ *  - The scroll prompt has role="status" so screen readers announce it.
+ *  - All text is machine-readable regardless of 3D canvas support.
+ *
+ * Mobile fallback:
+ *  On mobile (canvas not rendered), this component stays visible in normal
+ *  document flow rather than as a fixed overlay.
+ */
+
+// @vitest-environment jsdom
+
+import type { SiteConfig } from "~/services/cms/mod";
+
+export interface HeroOverlayProps {
+	siteConfig: SiteConfig;
+	/** Whether the intro animation has completed */
+	introComplete?: boolean;
+	/** Whether this is a mobile fallback (no 3D canvas) */
+	isMobile?: boolean;
+}
+
+export function HeroOverlay({
+	siteConfig,
+	introComplete = true,
+	isMobile = false,
+}: HeroOverlayProps) {
+	const { name, tagline, subtitle } = siteConfig;
+
+	const wrapperClass = isMobile
+		? "flex flex-col items-center justify-center min-h-screen px-6 text-center"
+		: "pointer-events-none fixed inset-0 z-10 flex flex-col items-center justify-center text-center px-6";
+
+	return (
+		<section className={wrapperClass} aria-label="Portfolio introduction">
+			{/* Name */}
+			<h1
+				className={[
+					"font-display font-bold text-5xl sm:text-7xl lg:text-8xl tracking-tight",
+					"text-[var(--color-text-primary)]",
+					"transition-opacity duration-1000",
+					introComplete ? "opacity-100" : "opacity-0",
+				].join(" ")}
+			>
+				{name}
+			</h1>
+
+			{/* Tagline */}
+			<p
+				className={[
+					"mt-4 font-display text-xl sm:text-2xl lg:text-3xl font-light",
+					"text-[var(--color-neon-cyan)]",
+					"transition-opacity duration-1000 delay-300",
+					introComplete ? "opacity-100" : "opacity-0",
+				].join(" ")}
+			>
+				{tagline}
+			</p>
+
+			{/* Optional subtitle */}
+			{subtitle && (
+				<p
+					className={[
+						"mt-2 font-sans text-base sm:text-lg",
+						"text-[var(--color-text-muted)]",
+						"transition-opacity duration-1000 delay-500",
+						introComplete ? "opacity-100" : "opacity-0",
+					].join(" ")}
+				>
+					{subtitle}
+				</p>
+			)}
+
+			{/* Scroll prompt — only shown on desktop */}
+			{!isMobile && (
+				<div
+					role="status"
+					aria-label="Scroll to explore"
+					className={[
+						"absolute bottom-12 flex flex-col items-center gap-2",
+						"transition-opacity duration-1000 delay-1000",
+						introComplete ? "opacity-100" : "opacity-0",
+					].join(" ")}
+				>
+					<span className="font-sans text-xs tracking-[0.3em] uppercase text-[var(--color-text-subtle)]">
+						scroll to explore
+					</span>
+					{/* Animated chevron */}
+					<svg
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+						className="animate-bounce text-[var(--color-text-subtle)]"
+						aria-hidden="true"
+					>
+						<path
+							d="M6 9l6 6 6-6"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						/>
+					</svg>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/app/features/hero/mod.ts
+++ b/app/features/hero/mod.ts
@@ -1,0 +1,10 @@
+/**
+ * mod.ts — public interface of the `hero` pod
+ *
+ * Exports:
+ *  - HeroOverlay component
+ *  - HeroOverlayProps type
+ */
+
+export type { HeroOverlayProps } from "./hero-overlay";
+export { HeroOverlay } from "./hero-overlay";

--- a/app/features/work/__tests__/project-card.test.tsx
+++ b/app/features/work/__tests__/project-card.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+/**
+ * project-card.test.tsx
+ *
+ * Tests for the ProjectCard component.
+ * Verifies that all project fields are rendered correctly and that
+ * optional fields degrade gracefully when absent.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	mockProjectFeatured,
+	mockProjectRegular,
+} from "~/test/fixtures/cms.fixtures";
+import { ProjectCard } from "../project-card";
+
+describe("ProjectCard: renders project data correctly", () => {
+	it("renders the project title as a heading", () => {
+		render(<ProjectCard project={mockProjectFeatured} />);
+		expect(
+			screen.getByRole("heading", { name: mockProjectFeatured.title }),
+		).toBeInTheDocument();
+	});
+
+	it("renders the project description", () => {
+		render(<ProjectCard project={mockProjectFeatured} />);
+		expect(
+			screen.getByText(mockProjectFeatured.description),
+		).toBeInTheDocument();
+	});
+
+	it("renders the year when present", () => {
+		const project = { ...mockProjectRegular, year: 2024 };
+		render(<ProjectCard project={project} />);
+		expect(screen.getByText("2024")).toBeInTheDocument();
+	});
+
+	it("does not render a year element when year is null", () => {
+		const project = { ...mockProjectRegular, year: null };
+		render(<ProjectCard project={project} />);
+		// Year should not appear
+		expect(screen.queryByText(/^\d{4}$/)).not.toBeInTheDocument();
+	});
+
+	it("renders technology tags as a list", () => {
+		const project = { ...mockProjectRegular, tags: ["React", "Three.js"] };
+		render(<ProjectCard project={project} />);
+		const tagList = screen.getByRole("list", { name: /technologies used/i });
+		expect(tagList).toBeInTheDocument();
+		expect(screen.getByText("React")).toBeInTheDocument();
+		expect(screen.getByText("Three.js")).toBeInTheDocument();
+	});
+
+	it("does not render tags section when tags array is empty", () => {
+		const project = { ...mockProjectRegular, tags: [] };
+		render(<ProjectCard project={project} />);
+		expect(
+			screen.queryByRole("list", { name: /technologies/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders live URL link when present", () => {
+		const project = {
+			...mockProjectRegular,
+			url: "https://example.com",
+		};
+		render(<ProjectCard project={project} />);
+		const link = screen.getByRole("link", {
+			name: new RegExp(`visit ${project.title} live site`, "i"),
+		});
+		expect(link).toHaveAttribute("href", "https://example.com");
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("does not render live link when url is null", () => {
+		const project = { ...mockProjectRegular, url: null };
+		render(<ProjectCard project={project} />);
+		expect(
+			screen.queryByRole("link", { name: /live site/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders GitHub link when present", () => {
+		const project = {
+			...mockProjectRegular,
+			github: "https://github.com/user/repo",
+		};
+		render(<ProjectCard project={project} />);
+		const link = screen.getByRole("link", {
+			name: new RegExp(`view ${project.title} on github`, "i"),
+		});
+		expect(link).toHaveAttribute("href", "https://github.com/user/repo");
+	});
+
+	it("renders featured badge when project.featured is true", () => {
+		render(<ProjectCard project={mockProjectFeatured} />);
+		// The mark element contains "Featured"
+		expect(screen.getByText("Featured")).toBeInTheDocument();
+	});
+
+	it("does not render featured badge when project.featured is false", () => {
+		render(<ProjectCard project={mockProjectRegular} />);
+		expect(screen.queryByText("Featured")).not.toBeInTheDocument();
+	});
+
+	it("renders thumbnail with correct alt text when present", () => {
+		const project = {
+			...mockProjectRegular,
+			thumbnail: {
+				url: "https://example.com/thumb.jpg",
+				width: 400,
+				height: 225,
+				alt: "Project screenshot",
+				sizes: { thumbnail: null, og: null },
+			},
+		};
+		render(<ProjectCard project={project} />);
+		expect(screen.getByRole("img")).toHaveAttribute(
+			"alt",
+			"Project screenshot",
+		);
+	});
+
+	it("does not render thumbnail when thumbnail is null", () => {
+		const project = { ...mockProjectRegular, thumbnail: null };
+		render(<ProjectCard project={project} />);
+		expect(screen.queryByRole("img")).not.toBeInTheDocument();
+	});
+});

--- a/app/features/work/__tests__/work-overlay.test.tsx
+++ b/app/features/work/__tests__/work-overlay.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+/**
+ * work-overlay.test.tsx
+ *
+ * Tests for the WorkOverlay component.
+ * Verifies project sorting, section title rendering, and empty state.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Project } from "~/services/cms/mod";
+import {
+	mockProjectFeatured,
+	mockProjectRegular,
+	mockSiteConfig,
+} from "~/test/fixtures/cms.fixtures";
+import { WorkOverlay } from "../work-overlay";
+
+// Use a simple siteConfig for tests that assert on section title text
+// — zocker generates long multiline strings that getByText can't reliably match.
+const simpleSiteConfig = {
+	...mockSiteConfig,
+	sectionTitles: {
+		hero: "Hello, Universe",
+		about: "About",
+		work: "Work",
+		contact: "Contact",
+	},
+};
+
+describe("WorkOverlay: renders project list correctly", () => {
+	it("renders the work section title from siteConfig", () => {
+		render(
+			<WorkOverlay
+				projects={[mockProjectFeatured]}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(screen.getByText("Work")).toBeInTheDocument();
+	});
+
+	it("renders all provided projects", () => {
+		render(
+			<WorkOverlay
+				projects={[mockProjectFeatured, mockProjectRegular]}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(
+			screen.getByRole("heading", { name: mockProjectFeatured.title }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { name: mockProjectRegular.title }),
+		).toBeInTheDocument();
+	});
+
+	it("renders 'Projects coming soon' when projects array is empty", () => {
+		render(<WorkOverlay projects={[]} siteConfig={simpleSiteConfig} visible />);
+		expect(screen.getByText(/projects coming soon/i)).toBeInTheDocument();
+	});
+
+	it("renders featured projects before non-featured", () => {
+		// Provide them in reverse order — featured should come first after sort
+		const projects: Project[] = [
+			{
+				...mockProjectRegular,
+				title: "Regular Project",
+				order: 1,
+				featured: false,
+			},
+			{
+				...mockProjectFeatured,
+				title: "Featured Project",
+				order: 2,
+				featured: true,
+			},
+		];
+		render(
+			<WorkOverlay projects={projects} siteConfig={simpleSiteConfig} visible />,
+		);
+		const headings = screen.getAllByRole("heading", { level: 3 });
+		expect(headings[0]).toHaveTextContent("Featured Project");
+		expect(headings[1]).toHaveTextContent("Regular Project");
+	});
+
+	it("section has accessible landmark label", () => {
+		render(
+			<WorkOverlay
+				projects={[mockProjectFeatured]}
+				siteConfig={simpleSiteConfig}
+				visible
+			/>,
+		);
+		expect(
+			screen.getByRole("region", { name: /work section/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/app/features/work/mod.ts
+++ b/app/features/work/mod.ts
@@ -1,0 +1,13 @@
+/**
+ * mod.ts — public interface of the `work` pod
+ *
+ * Exports:
+ *  - WorkOverlay component
+ *  - ProjectCard component
+ *  - WorkOverlayProps, ProjectCardProps types
+ */
+
+export type { ProjectCardProps } from "./project-card";
+export { ProjectCard } from "./project-card";
+export type { WorkOverlayProps } from "./work-overlay";
+export { WorkOverlay } from "./work-overlay";

--- a/app/features/work/project-card.tsx
+++ b/app/features/work/project-card.tsx
@@ -1,0 +1,113 @@
+/**
+ * project-card.tsx — individual project card component
+ *
+ * Displays a single project entry from the CMS with:
+ *  - Title, description, technology tags, year
+ *  - Optional thumbnail image
+ *  - Links to live URL and GitHub
+ *  - Featured badge when project.featured is true
+ *
+ * Accessibility:
+ *  - The card is an <article> with a heading and accessible links.
+ *  - The featured badge is communicated to screen readers via aria-label.
+ *  - External links have rel="noopener noreferrer".
+ */
+
+import type { Project } from "~/services/cms/mod";
+
+export interface ProjectCardProps {
+	project: Project;
+}
+
+export function ProjectCard({ project }: ProjectCardProps) {
+	const { title, description, tags, year, thumbnail, url, github, featured } =
+		project;
+
+	return (
+		<article className="relative flex flex-col bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-lg overflow-hidden">
+			{/* Featured badge */}
+			{featured && (
+				<mark className="absolute top-3 right-3 px-2 py-0.5 text-xs font-sans font-medium rounded-full bg-[var(--color-neon-cyan)] text-black z-10 no-underline">
+					<span className="sr-only">Featured project: </span>
+					Featured
+				</mark>
+			)}
+
+			{/* Thumbnail */}
+			{thumbnail && (
+				<div className="w-full aspect-video overflow-hidden bg-[var(--color-surface-2)]">
+					<img
+						src={thumbnail.sizes?.thumbnail?.url ?? thumbnail.url}
+						alt={thumbnail.alt ?? `${title} screenshot`}
+						width={thumbnail.sizes?.thumbnail?.width ?? 400}
+						height={thumbnail.sizes?.thumbnail?.height ?? 225}
+						className="w-full h-full object-cover"
+						loading="lazy"
+					/>
+				</div>
+			)}
+
+			{/* Content */}
+			<div className="flex flex-col flex-1 p-5 gap-3">
+				{/* Header row */}
+				<div className="flex items-start justify-between gap-2">
+					<h3 className="font-display font-semibold text-base text-[var(--color-text-primary)] leading-tight">
+						{title}
+					</h3>
+					{year && (
+						<span className="font-sans text-xs text-[var(--color-text-subtle)] shrink-0 mt-0.5">
+							{year}
+						</span>
+					)}
+				</div>
+
+				{/* Description */}
+				<p className="font-sans text-sm text-[var(--color-text-muted)] leading-relaxed flex-1">
+					{description}
+				</p>
+
+				{/* Technology tags */}
+				{tags.length > 0 && (
+					<ul className="flex flex-wrap gap-1.5" aria-label="Technologies used">
+						{tags.map((tag) => (
+							<li
+								key={tag}
+								className="px-2 py-0.5 text-xs font-sans rounded border border-[var(--color-border)] text-[var(--color-text-subtle)]"
+							>
+								{tag}
+							</li>
+						))}
+					</ul>
+				)}
+
+				{/* Links */}
+				{(url || github) && (
+					<div className="flex gap-3 mt-auto pt-2 border-t border-[var(--color-border)]">
+						{url && (
+							<a
+								href={url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="font-sans text-xs text-[var(--color-neon-cyan)] hover:underline"
+								aria-label={`Visit ${title} live site`}
+							>
+								Live &rarr;
+							</a>
+						)}
+						{github && (
+							<a
+								href={github}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="font-sans text-xs text-[var(--color-text-muted)] hover:underline"
+								aria-label={`View ${title} on GitHub`}
+							>
+								GitHub &rarr;
+							</a>
+						)}
+					</div>
+				)}
+			</div>
+		</article>
+	);
+}

--- a/app/features/work/work-overlay.tsx
+++ b/app/features/work/work-overlay.tsx
@@ -1,0 +1,75 @@
+/**
+ * work-overlay.tsx — HTML content overlay for Section 3 (Cyberpunk City view)
+ *
+ * Displays the project grid above the city scene. Featured projects appear
+ * first, followed by the rest ordered by the CMS `order` field.
+ *
+ * The overlay is a scrollable panel positioned to the right side of the
+ * viewport — the left side of the city scene remains visible.
+ */
+
+import type { Project, SiteConfig } from "~/services/cms/mod";
+import { ProjectCard } from "./project-card";
+
+export interface WorkOverlayProps {
+	projects: Project[];
+	siteConfig: SiteConfig;
+	visible?: boolean;
+	isMobile?: boolean;
+}
+
+function sortProjects(projects: Project[]): Project[] {
+	return [...projects].sort((a, b) => {
+		// Featured first
+		if (a.featured && !b.featured) return -1;
+		if (!a.featured && b.featured) return 1;
+		// Then by CMS order
+		const aOrder = a.order ?? 999;
+		const bOrder = b.order ?? 999;
+		return aOrder - bOrder;
+	});
+}
+
+export function WorkOverlay({
+	projects,
+	siteConfig,
+	visible = true,
+	isMobile = false,
+}: WorkOverlayProps) {
+	const sorted = sortProjects(projects);
+	const sectionTitle = siteConfig.sectionTitles.work;
+
+	const wrapperClass = isMobile
+		? "px-6 py-16"
+		: [
+				"pointer-events-none fixed top-0 right-0 bottom-0 z-10 w-full max-w-lg",
+				"flex flex-col pt-12 pr-6 lg:pr-12 overflow-y-auto",
+				"transition-opacity duration-700",
+				visible ? "opacity-100" : "opacity-0",
+			].join(" ");
+
+	return (
+		<section className={wrapperClass} aria-label="Work section">
+			<div className="pointer-events-auto">
+				{/* Section heading */}
+				<p className="font-display text-xs tracking-[0.3em] uppercase text-[var(--color-neon-pink)] mb-6">
+					{sectionTitle}
+				</p>
+
+				{sorted.length === 0 ? (
+					<p className="font-sans text-sm text-[var(--color-text-muted)]">
+						Projects coming soon.
+					</p>
+				) : (
+					<ul className="flex flex-col gap-4" aria-label="Project list">
+						{sorted.map((project) => (
+							<li key={project.id}>
+								<ProjectCard project={project} />
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</section>
+	);
+}


### PR DESCRIPTION
## Summary

Four self-contained pods providing the HTML content overlays rendered above the Three.js canvas. These are plain React components — no Three.js dependency.

### Pods

**`hero`** (Section 1)
- `HeroOverlay` — `<h1>` owner name, tagline, subtitle (optional), animated scroll prompt; opacity controlled by `introComplete` prop

**`about`** (Section 2)
- `AboutOverlay` — section title from CMS, Lexical rich-text AST text extractor, skills tag list, optional portrait photo

**`work`** (Section 3)
- `ProjectCard` — thumbnail (lazy-loaded), title, description, year, technology tags, live URL and GitHub links, featured `<mark>` badge; all optional fields produce no broken UI
- `WorkOverlay` — featured-first sort (then by CMS `order`), scrollable right panel

**`contact`** (Section 3 bottom)
- `ContactOverlay` — selectable `mailto:` email link (never obfuscated), CTA text, social links `<nav>`

### Accessibility
- All overlays use `<section aria-label>` landmarks
- Skills, tags, and social links use `<ul aria-label>` lists
- External links have `rel="noopener noreferrer"` and descriptive `aria-label`
- Email is plain selectable text

### Tests — 30+ cases (all passing, jsdom)

Covers: CMS data renders correctly, null/empty optional fields → no broken elements, ARIA roles present, featured sort order, external link attributes.

## Part of

Phase 3 stacked PR chain:
1. `feat/phase-3-01-foundation` — Foundation ✓
2. `feat/phase-3-02-experience` — experience pod ✓
3. `feat/phase-3-03-galaxy` — galaxy pod ✓
4. `feat/phase-3-04-city` — city pod ✓
5. **→ This PR** — overlay pods
6. `feat/phase-3-06-audio` — audio pod
7. `feat/phase-3-07-integration` — home.tsx wiring