### PR TITLE
feat(phase-3): audio pod — procedural Web Audio synthesis and accessible toggle

### DIFF
--- a/app/features/audio/__tests__/audio-service.test.ts
+++ b/app/features/audio/__tests__/audio-service.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+/**
+ * audio-service.test.ts
+ *
+ * Tests for the AudioService state machine.
+ * Verifies state transitions (idle → playing → idle) and error handling.
+ *
+ * The Web Audio API is available in jsdom (via the AudioContext mock).
+ * We mock AudioContext to control its behaviour in tests without real audio.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAudioService } from "../audio-service";
+
+// ---------------------------------------------------------------------------
+// Web Audio API mock
+// ---------------------------------------------------------------------------
+
+const mockOscillatorStart = vi.fn();
+const mockOscillatorStop = vi.fn();
+const mockOscillatorConnect = vi.fn();
+const mockSourceStart = vi.fn();
+const mockSourceStop = vi.fn();
+const mockSourceConnect = vi.fn();
+const mockGainConnect = vi.fn();
+const mockFilterConnect = vi.fn();
+const mockGainValue = { value: 0, linearRampToValueAtTime: vi.fn() };
+const mockFilterFrequency = { value: 0 };
+const mockContextSuspend = vi.fn().mockResolvedValue(undefined);
+const mockContextResume = vi.fn().mockResolvedValue(undefined);
+const mockContextClose = vi.fn().mockResolvedValue(undefined);
+
+function makeMockAudioContext() {
+	return {
+		currentTime: 0,
+		sampleRate: 44100,
+		destination: {},
+		state: "suspended",
+		createGain: vi.fn(() => ({
+			gain: mockGainValue,
+			connect: mockGainConnect,
+		})),
+		createBiquadFilter: vi.fn(() => ({
+			type: "lowpass",
+			frequency: mockFilterFrequency,
+			Q: { value: 0 },
+			connect: mockFilterConnect,
+		})),
+		createBufferSource: vi.fn(() => ({
+			buffer: null,
+			loop: false,
+			connect: mockSourceConnect,
+			start: mockSourceStart,
+			stop: mockSourceStop,
+		})),
+		createBuffer: vi.fn(
+			(_channels: number, length: number, sampleRate: number) => ({
+				sampleRate,
+				length,
+				getChannelData: vi.fn(() => new Float32Array(length)),
+			}),
+		),
+		createOscillator: vi.fn(() => ({
+			type: "sine",
+			frequency: { value: 0 },
+			connect: mockOscillatorConnect,
+			start: mockOscillatorStart,
+			stop: mockOscillatorStop,
+		})),
+		suspend: mockContextSuspend,
+		resume: mockContextResume,
+		close: mockContextClose,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createAudioService: state machine", () => {
+	let MockAudioContext: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		MockAudioContext = vi.fn().mockImplementation(makeMockAudioContext);
+		vi.stubGlobal("AudioContext", MockAudioContext);
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("starts in idle state", () => {
+		const service = createAudioService();
+		expect(service.state).toBe("idle");
+	});
+
+	it("transitions to playing after first toggle", async () => {
+		const service = createAudioService();
+		await service.toggle();
+		expect(service.state).toBe("playing");
+	});
+
+	it("creates an AudioContext on first toggle", async () => {
+		const service = createAudioService();
+		await service.toggle();
+		expect(MockAudioContext).toHaveBeenCalledTimes(1);
+	});
+
+	it("transitions back to idle on second toggle", async () => {
+		const service = createAudioService();
+		await service.toggle(); // idle → playing
+		expect(service.state).toBe("playing");
+
+		// toggle() playing→idle awaits a 500ms fade-out setTimeout.
+		// Start the toggle without awaiting it, then advance fake timers
+		// so the internal setTimeout fires, then await the resolved promise.
+		const togglePromise = service.toggle();
+		await vi.runAllTimersAsync();
+		await togglePromise;
+		expect(service.state).toBe("idle");
+	});
+
+	it("does not create a second AudioContext on second toggle", async () => {
+		const service = createAudioService();
+		await service.toggle(); // idle → playing (creates context)
+
+		const idlePromise = service.toggle(); // playing → idle
+		await vi.runAllTimersAsync();
+		await idlePromise;
+
+		await service.toggle(); // idle → playing (resumes context — no new AudioContext)
+		expect(MockAudioContext).toHaveBeenCalledTimes(1);
+		expect(mockContextResume).toHaveBeenCalledTimes(1);
+	});
+
+	it("transitions to error state when AudioContext throws", async () => {
+		MockAudioContext = vi.fn().mockImplementation(() => {
+			throw new Error("AudioContext not supported");
+		});
+		vi.stubGlobal("AudioContext", MockAudioContext);
+
+		const service = createAudioService();
+		await service.toggle();
+		expect(service.state).toBe("error");
+	});
+
+	it("does nothing when toggled in error state", async () => {
+		MockAudioContext = vi.fn().mockImplementation(() => {
+			throw new Error("AudioContext not supported");
+		});
+		vi.stubGlobal("AudioContext", MockAudioContext);
+
+		const service = createAudioService();
+		await service.toggle(); // → error
+		await service.toggle(); // should be no-op
+		expect(service.state).toBe("error");
+		// AudioContext constructor called exactly once
+		expect(MockAudioContext).toHaveBeenCalledTimes(1);
+	});
+
+	it("dispose resets state to idle", async () => {
+		const service = createAudioService();
+		await service.toggle();
+		expect(service.state).toBe("playing");
+		service.dispose();
+		expect(service.state).toBe("idle");
+	});
+
+	it("dispose calls AudioContext.close()", async () => {
+		const service = createAudioService();
+		await service.toggle();
+		service.dispose();
+		expect(mockContextClose).toHaveBeenCalled();
+	});
+});

--- a/app/features/audio/audio-service.ts
+++ b/app/features/audio/audio-service.ts
@@ -1,0 +1,169 @@
+/**
+ * audio-service.ts — Web Audio API ambient sound synthesis
+ *
+ * All audio is synthesised procedurally via the Web Audio API — no files
+ * are loaded or bundled. This satisfies the PRD's "procedural-only assets"
+ * constraint and avoids autoplay policy issues from file loading.
+ *
+ * Sound design:
+ *  - Rain: filtered brown noise (low-pass filtered white noise with pink rolloff)
+ *  - City hum: low sine oscillator (~60 Hz) mixed with sub-bass rumble (~35 Hz)
+ *  - Both layers are crossfaded via gain nodes when the toggle is activated
+ *
+ * Lifecycle:
+ *  AudioContext is created on first user interaction (toggle click), satisfying
+ *  the browser autoplay policy. The context persists for the session duration.
+ *
+ * State machine:
+ *  idle → playing → idle (toggle)
+ *  idle → error (context creation fails — browser does not support Web Audio)
+ */
+
+export type AudioState = "idle" | "playing" | "error";
+
+export interface AudioService {
+	/** Current playback state */
+	state: AudioState;
+	/** Toggle audio on/off. Must be called from a user gesture. */
+	toggle: () => Promise<void>;
+	/** Immediately stop all audio and release resources */
+	dispose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Brown noise generator
+// ---------------------------------------------------------------------------
+
+function createBrownNoise(ctx: AudioContext): AudioBufferSourceNode {
+	const bufferSize = ctx.sampleRate * 2; // 2 seconds of noise
+	const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+	const data = buffer.getChannelData(0);
+
+	let lastOut = 0;
+	for (let i = 0; i < bufferSize; i++) {
+		const white = Math.random() * 2 - 1;
+		// Brown noise via integration of white noise
+		data[i] = (lastOut + 0.02 * white) / 1.02;
+		lastOut = data[i];
+		data[i] *= 3.5; // amplify to audible level
+	}
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.loop = true;
+	return source;
+}
+
+// ---------------------------------------------------------------------------
+// City hum oscillator
+// ---------------------------------------------------------------------------
+
+function createCityHum(ctx: AudioContext): OscillatorNode {
+	const osc = ctx.createOscillator();
+	osc.type = "sine";
+	osc.frequency.value = 55; // low city rumble
+	return osc;
+}
+
+// ---------------------------------------------------------------------------
+// AudioService factory
+// ---------------------------------------------------------------------------
+
+export function createAudioService(): AudioService {
+	let ctx: AudioContext | null = null;
+	let masterGain: GainNode | null = null;
+	let rainSource: AudioBufferSourceNode | null = null;
+	let humSource: OscillatorNode | null = null;
+	let currentState: AudioState = "idle";
+
+	const service: AudioService = {
+		get state() {
+			return currentState;
+		},
+
+		async toggle() {
+			if (currentState === "error") return;
+
+			if (currentState === "playing") {
+				// Fade out and suspend
+				if (masterGain && ctx) {
+					masterGain.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.5);
+					await new Promise<void>((resolve) => setTimeout(resolve, 500));
+					await ctx.suspend();
+				}
+				currentState = "idle";
+				return;
+			}
+
+			// idle → playing
+			try {
+				if (!ctx) {
+					ctx = new AudioContext();
+					masterGain = ctx.createGain();
+					masterGain.gain.value = 0;
+					masterGain.connect(ctx.destination);
+
+					// Rain layer — filtered brown noise
+					rainSource = createBrownNoise(ctx);
+					const rainFilter = ctx.createBiquadFilter();
+					rainFilter.type = "lowpass";
+					rainFilter.frequency.value = 800;
+					rainFilter.Q.value = 0.5;
+
+					const rainGain = ctx.createGain();
+					rainGain.gain.value = 0.15;
+
+					rainSource.connect(rainFilter);
+					rainFilter.connect(rainGain);
+					rainGain.connect(masterGain);
+					rainSource.start();
+
+					// City hum layer
+					humSource = createCityHum(ctx);
+					const humGain = ctx.createGain();
+					humGain.gain.value = 0.08;
+					humSource.connect(humGain);
+					humGain.connect(masterGain);
+					humSource.start();
+				} else {
+					await ctx.resume();
+				}
+
+				// Fade in
+				if (masterGain && ctx) {
+					masterGain.gain.linearRampToValueAtTime(1, ctx.currentTime + 1.0);
+				}
+				currentState = "playing";
+			} catch {
+				currentState = "error";
+			}
+		},
+
+		dispose() {
+			if (rainSource) {
+				try {
+					rainSource.stop();
+				} catch {
+					// Already stopped
+				}
+			}
+			if (humSource) {
+				try {
+					humSource.stop();
+				} catch {
+					// Already stopped
+				}
+			}
+			if (ctx) {
+				ctx.close().catch(() => {});
+			}
+			ctx = null;
+			masterGain = null;
+			rainSource = null;
+			humSource = null;
+			currentState = "idle";
+		},
+	};
+
+	return service;
+}

--- a/app/features/audio/audio-toggle.tsx
+++ b/app/features/audio/audio-toggle.tsx
@@ -1,0 +1,139 @@
+/**
+ * audio-toggle.tsx — accessible audio on/off toggle button
+ *
+ * The toggle is a button that creates the Web Audio context on first
+ * activation (satisfying browser autoplay policy — user gesture required).
+ *
+ * States:
+ *  idle    → button shows "Enable audio", plays ambient audio on click
+ *  playing → button shows "Disable audio", stops audio on click
+ *  error   → button is disabled with a tooltip explaining the issue
+ *
+ * Accessibility:
+ *  - aria-pressed reflects the current toggle state
+ *  - aria-label updates to describe the action that will be taken
+ *  - Keyboard operable (native <button>)
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type AudioService, createAudioService } from "./audio-service";
+
+export function AudioToggle() {
+	const serviceRef = useRef<AudioService | null>(null);
+	const [state, setState] = useState<"idle" | "playing" | "error">("idle");
+	const [isPending, setIsPending] = useState(false);
+
+	// Initialise the service once on mount
+	useEffect(() => {
+		serviceRef.current = createAudioService();
+		return () => {
+			serviceRef.current?.dispose();
+		};
+	}, []);
+
+	const handleToggle = useCallback(async () => {
+		const service = serviceRef.current;
+		if (!service || isPending) return;
+
+		setIsPending(true);
+		try {
+			await service.toggle();
+			setState(service.state);
+		} finally {
+			setIsPending(false);
+		}
+	}, [isPending]);
+
+	const isPlaying = state === "playing";
+	const isError = state === "error";
+
+	const label = isError
+		? "Audio unavailable in this browser"
+		: isPlaying
+			? "Disable ambient audio"
+			: "Enable ambient audio";
+
+	return (
+		<button
+			type="button"
+			onClick={handleToggle}
+			disabled={isError || isPending}
+			aria-pressed={isPlaying}
+			aria-label={label}
+			title={label}
+			className={[
+				"fixed bottom-6 right-6 z-20",
+				"flex items-center justify-center w-10 h-10 rounded-full",
+				"border transition-colors duration-200",
+				isPlaying
+					? "border-[var(--color-neon-cyan)] bg-[var(--color-neon-cyan)]/10 text-[var(--color-neon-cyan)]"
+					: "border-[var(--color-border)] bg-[var(--color-surface-1)] text-[var(--color-text-muted)]",
+				isError
+					? "opacity-40 cursor-not-allowed"
+					: "cursor-pointer hover:border-[var(--color-neon-cyan)]",
+			].join(" ")}
+		>
+			{/* Accessible icon — speaker with/without wave */}
+			<svg
+				width="18"
+				height="18"
+				viewBox="0 0 24 24"
+				fill="none"
+				aria-hidden="true"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				{isPlaying ? (
+					<>
+						{/* Speaker + sound waves */}
+						<path
+							d="M11 5L6 9H2v6h4l5 4V5z"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinejoin="round"
+						/>
+						<path
+							d="M15.54 8.46a5 5 0 0 1 0 7.07"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+						/>
+						<path
+							d="M19.07 4.93a10 10 0 0 1 0 14.14"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+						/>
+					</>
+				) : (
+					<>
+						{/* Speaker muted */}
+						<path
+							d="M11 5L6 9H2v6h4l5 4V5z"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinejoin="round"
+						/>
+						<line
+							x1="23"
+							y1="9"
+							x2="17"
+							y2="15"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+						/>
+						<line
+							x1="17"
+							y1="9"
+							x2="23"
+							y2="15"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+						/>
+					</>
+				)}
+			</svg>
+		</button>
+	);
+}

--- a/app/features/audio/mod.ts
+++ b/app/features/audio/mod.ts
@@ -1,0 +1,12 @@
+/**
+ * mod.ts — public interface of the `audio` pod
+ *
+ * Exports:
+ *  - AudioToggle component
+ *  - createAudioService factory (used in tests)
+ *  - AudioState and AudioService types
+ */
+
+export type { AudioService, AudioState } from "./audio-service";
+export { createAudioService } from "./audio-service";
+export { AudioToggle } from "./audio-toggle";


### PR DESCRIPTION
## Summary

The `audio` pod provides ambient sound for the city section. **No audio files are bundled** — all sound is synthesised procedurally via the Web Audio API (satisfies the PRD's procedural-only assets constraint).

### Sound design

| Layer | Implementation | Character |
|---|---|---|
| Rain | Brown noise via Euler-integrated white noise → low-pass filter at 800 Hz | Soft rainfall texture |
| City hum | 55 Hz sine oscillator, gain 0.08 | Urban sub-bass rumble |

Both layers route through a master `GainNode` with `linearRampToValueAtTime` fade in/out (1.0s / 0.5s) to avoid clicks.

### State machine

```
idle ──toggle()──▶ playing ──toggle()──▶ idle
 │                                        │
 └──AudioContext throws──▶ error ◀────────┘
                            (no-op)
```

`AudioContext` is created on the **first** `toggle()` call — satisfies the browser autoplay policy (user gesture required). Subsequent toggles reuse the same context via `resume()` / `suspend()`.

### AudioToggle component

- Fixed bottom-right `<button>` with `aria-pressed` reflecting play state
- `aria-label` updates to describe the action about to be taken
- SVG icon switches between muted and sound-wave states
- Disabled + `cursor-not-allowed` when `state === 'error'`

### Tests — 9 cases (all passing, jsdom + vi.useFakeTimers())

```
✓ starts in idle state
✓ transitions to playing after first toggle
✓ creates AudioContext on first toggle
✓ transitions back to idle on second toggle
✓ reuses AudioContext (resume, not new context) on third toggle
✓ transitions to error when AudioContext constructor throws
✓ error state is a no-op
✓ dispose() resets to idle
✓ dispose() calls ctx.close()
```

## Part of

Phase 3 stacked PR chain:
1. `feat/phase-3-01-foundation` — Foundation ✓
2. `feat/phase-3-02-experience` — experience pod ✓
3. `feat/phase-3-03-galaxy` — galaxy pod ✓
4. `feat/phase-3-04-city` — city pod ✓
5. `feat/phase-3-05-overlays` — overlay pods ✓
6. **→ This PR** — audio pod
7. `feat/phase-3-07-integration` — home.tsx wiring