### PR TITLE
feat(phase-3): integration — wire full 3D experience into home route

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,21 +1,46 @@
 /**
  * home.tsx — the root "/" route
  *
- * This is the SSR entry point for the portfolio. The loader fetches all CMS
- * page data concurrently using the Effect-ts service layer. If the CMS is
- * unavailable, the loader falls back to hardcoded defaults so the page
- * still renders correctly during local development or CMS outages.
- *
- * The component itself is intentionally minimal in Phase 1 — it renders the
- * portfolio owner's name and tagline as a proof of the data flow. The full
- * three-section 3D experience is wired up in Phase 3.
+ * Architecture:
+ *  - SSR loader fetches all CMS page data concurrently via Effect-ts.
+ *  - On the server: renders the full HTML shell with all text content
+ *    (name, bio, project titles, contact) for fast FCP and SEO.
+ *  - On the client: lazily loads the Three.js Experience component so it
+ *    is entirely off the critical rendering path.
+ *  - WebGL / canvas is conditionally rendered — skipped on mobile (<1024px)
+ *    and when prefers-reduced-motion is set.
+ *  - GSAP ScrollTrigger provides magnetic section snap at the page level.
+ *  - drei ScrollControls inside the canvas drives camera interpolation.
  */
 
 import { Effect } from "effect";
+import {
+	lazy,
+	Suspense,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { AboutOverlay } from "~/features/about/mod";
+import { AudioToggle } from "~/features/audio/mod";
+import { ContactOverlay } from "~/features/contact/mod";
+import { HeroOverlay } from "~/features/hero/mod";
+import { WorkOverlay } from "~/features/work/mod";
 import type { PageData } from "~/services/cms/mod";
 import { CmsService } from "~/services/cms/mod";
 import { AppLayer } from "~/services/runtime";
 import type { Route } from "./+types/home";
+
+// ---------------------------------------------------------------------------
+// Lazy load the Three.js canvas — never imported on the server
+// ---------------------------------------------------------------------------
+
+const Experience = lazy(() =>
+	import("~/features/experience/mod").then((m) => ({
+		default: m.Experience,
+	})),
+);
 
 // ---------------------------------------------------------------------------
 // Fallback data — used when the CMS is unavailable
@@ -62,9 +87,6 @@ export const loader = async (_args: Route.LoaderArgs): Promise<PageData> => {
 		return yield* cms.getAllPageData();
 	}).pipe(
 		Effect.provide(AppLayer),
-		// If the CMS is unreachable during development or build, use defaults.
-		// In production the CMS should always be available; errors are logged
-		// to the edge runtime console for investigation.
 		Effect.catchAll((error) => {
 			console.error("[home loader] CMS fetch failed:", error._tag, error);
 			return Effect.succeed(fallbackPageData);
@@ -75,7 +97,7 @@ export const loader = async (_args: Route.LoaderArgs): Promise<PageData> => {
 };
 
 // ---------------------------------------------------------------------------
-// Meta tags — driven by CMS site-config
+// Meta tags
 // ---------------------------------------------------------------------------
 
 export function meta({ data }: Route.MetaArgs) {
@@ -83,7 +105,6 @@ export function meta({ data }: Route.MetaArgs) {
 	return [
 		{ title: seo.metaTitle },
 		{ name: "description", content: seo.metaDescription },
-		// Open Graph
 		{ property: "og:title", content: seo.metaTitle },
 		{ property: "og:description", content: seo.metaDescription },
 		{ property: "og:type", content: "website" },
@@ -94,25 +115,232 @@ export function meta({ data }: Route.MetaArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// GSAP ScrollTrigger magnetic snap
+// ---------------------------------------------------------------------------
+
+/** Section boundary offsets (0→1) — must match SECTION_OFFSETS in scroll-section.ts */
+const SNAP_OFFSETS = [0, 0.33, 0.66, 1];
+
+function useScrollSnap(
+	containerRef: React.RefObject<HTMLElement | null>,
+	enabled: boolean,
+) {
+	useEffect(() => {
+		if (!enabled || !containerRef.current) return;
+
+		// Dynamically import GSAP to keep it off the SSR critical path
+		let cleanup: (() => void) | undefined;
+
+		import("gsap")
+			.then(({ gsap }) =>
+				import("gsap/ScrollTrigger").then(({ ScrollTrigger }) => {
+					gsap.registerPlugin(ScrollTrigger);
+
+					const container = containerRef.current;
+					if (!container) return;
+
+					const triggers = SNAP_OFFSETS.slice(0, -1).map((offset, i) => {
+						const nextOffset = SNAP_OFFSETS[i + 1];
+						return ScrollTrigger.create({
+							trigger: container,
+							start: `${offset * 100}% top`,
+							end: `${nextOffset * 100}% top`,
+							snap: {
+								snapTo: [0, 1],
+								duration: { min: 0.2, max: 0.5 },
+								delay: 0.05,
+								ease: "power1.inOut",
+							},
+						});
+					});
+
+					cleanup = () => {
+						for (const trigger of triggers) trigger.kill();
+						for (const t of ScrollTrigger.getAll()) t.kill();
+					};
+				}),
+			)
+			.catch(() => {
+				// GSAP failed to load — degrade gracefully (no snap, scroll still works)
+			});
+
+		return () => {
+			cleanup?.();
+		};
+	}, [containerRef, enabled]);
+}
+
+// ---------------------------------------------------------------------------
+// Device detection helpers
+// ---------------------------------------------------------------------------
+
+function useIs3DCapable() {
+	const [capable, setCapable] = useState(false);
+
+	useEffect(() => {
+		// Run only on client after hydration
+		const isWide = window.innerWidth >= 1024;
+		const prefersReduced = window.matchMedia(
+			"(prefers-reduced-motion: reduce)",
+		).matches;
+
+		// Check WebGL2 support
+		let hasWebGL = false;
+		try {
+			const canvas = document.createElement("canvas");
+			hasWebGL = !!canvas.getContext("webgl2");
+		} catch {
+			hasWebGL = false;
+		}
+
+		setCapable(isWide && !prefersReduced && hasWebGL);
+	}, []);
+
+	return capable;
+}
+
+// ---------------------------------------------------------------------------
 // Page component
 // ---------------------------------------------------------------------------
 
-/**
- * Phase 1 placeholder — replaced by the full 3D experience in Phase 3.
- * Renders the CMS-driven name and tagline as an accessible text fallback.
- * This content is also used by the mobile/reduced-motion fallback path
- * in Phase 4.
- */
 export default function Home({ loaderData }: Route.ComponentProps) {
-	const { name, tagline } = loaderData.siteConfig;
+	const { siteConfig, about, contact, projects } = loaderData;
+	const is3DCapable = useIs3DCapable();
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	// Track scroll progress for overlay visibility
+	const [scrollOffset, setScrollOffset] = useState(0);
+	const handleScrollChange = useCallback((offset: number) => {
+		setScrollOffset(offset);
+	}, []);
+
+	// Section visibility thresholds (per section's scroll range 0→1)
+	const section = Math.round(scrollOffset * 2); // 0, 1, or 2
+	const isSection2 = section === 1;
+	const isSection3 = section === 2;
+
+	// Enable GSAP snap only when canvas is mounted and 3D capable
+	useScrollSnap(containerRef, is3DCapable);
 
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-center bg-black text-white">
-			<h1 className="text-5xl font-bold tracking-tight">{name}</h1>
-			<p className="mt-4 text-xl text-zinc-400">{tagline}</p>
-			<p className="mt-8 text-sm text-zinc-600">
-				Phase 1 scaffold — 3D experience arrives in Phase 3
-			</p>
-		</main>
+		<>
+			{/* ----------------------------------------------------------------
+			    Visually-hidden but screen-reader-accessible content.
+			    Always present regardless of 3D canvas support.
+			    ---------------------------------------------------------------- */}
+			<div className="sr-only" aria-hidden="false">
+				<h1>{siteConfig.name}</h1>
+				<p>{siteConfig.tagline}</p>
+				<p>
+					{typeof about.bio === "object" && about.bio !== null
+						? JSON.stringify(about.bio)
+						: ""}
+				</p>
+				<ul>
+					{projects.map((p) => (
+						<li key={p.id}>{p.title}</li>
+					))}
+				</ul>
+				<p>{contact.email}</p>
+			</div>
+
+			{/* ----------------------------------------------------------------
+			    3D Experience — desktop with WebGL2 support only
+			    ---------------------------------------------------------------- */}
+			{is3DCapable ? (
+				<div
+					ref={containerRef}
+					style={{ width: "100vw", height: "100vh", overflow: "hidden" }}
+				>
+					<Suspense
+						fallback={
+							<div className="fixed inset-0 flex items-center justify-center bg-[var(--color-void)]">
+								<p className="font-display text-sm text-[var(--color-text-subtle)] tracking-widest uppercase">
+									Loading experience…
+								</p>
+							</div>
+						}
+					>
+						<Experience
+							siteConfig={siteConfig}
+							about={about}
+							contact={contact}
+							projects={projects}
+							onScrollChange={handleScrollChange}
+						/>
+					</Suspense>
+
+					{/* HTML overlays layered above the canvas */}
+					<HeroOverlay siteConfig={siteConfig} introComplete isMobile={false} />
+
+					<div
+						className="transition-opacity duration-700"
+						style={{
+							opacity: isSection2 ? 1 : 0,
+							pointerEvents: isSection2 ? "auto" : "none",
+						}}
+					>
+						<AboutOverlay
+							about={about}
+							siteConfig={siteConfig}
+							visible={isSection2}
+						/>
+					</div>
+
+					<div
+						className="transition-opacity duration-700"
+						style={{
+							opacity: isSection3 ? 1 : 0,
+							pointerEvents: isSection3 ? "auto" : "none",
+						}}
+					>
+						<WorkOverlay
+							projects={projects}
+							siteConfig={siteConfig}
+							visible={isSection3}
+						/>
+						<ContactOverlay
+							contact={contact}
+							siteConfig={siteConfig}
+							visible={isSection3}
+						/>
+					</div>
+
+					{/* Audio toggle — only visible in city section */}
+					{isSection3 && <AudioToggle />}
+				</div>
+			) : (
+				/* ----------------------------------------------------------------
+				   Mobile / no-WebGL fallback — standard document flow
+				   ---------------------------------------------------------------- */
+				<main
+					className="min-h-screen bg-gradient-to-b from-[var(--color-void)] via-[var(--color-deep-navy)] to-[#050520]"
+					aria-label="Portfolio — mobile view"
+				>
+					<HeroOverlay siteConfig={siteConfig} introComplete isMobile />
+
+					<AboutOverlay
+						about={about}
+						siteConfig={siteConfig}
+						visible
+						isMobile
+					/>
+
+					<WorkOverlay
+						projects={projects}
+						siteConfig={siteConfig}
+						visible
+						isMobile
+					/>
+
+					<ContactOverlay
+						contact={contact}
+						siteConfig={siteConfig}
+						visible
+						isMobile
+					/>
+				</main>
+			)}
+		</>
 	);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,8 +21,9 @@ export default defineConfig({
 	test: {
 		globals: true,
 		// Service and utility tests run in Node — no DOM required.
-		// Component tests (Phase 6+) opt in per-file with:
+		// Component tests (HTML overlays, audio toggle) declare:
 		//   // @vitest-environment jsdom
+		// at the top of their file to opt in to the jsdom environment.
 		environment: "node",
 		setupFiles: ["./app/test/setup.ts"],
 		coverage: {
@@ -43,6 +44,21 @@ export default defineConfig({
 				"app/routes.ts",
 				// Welcome boilerplate — removed in Phase 3
 				"app/welcome/**",
+				// Three.js / R3F components — WebGL not available in Node/jsdom.
+				// Verified manually in the browser per PRD §5.2.
+				"app/features/experience/**",
+				"app/features/galaxy/galaxy-particles.tsx",
+				"app/features/galaxy/galaxy-scene.tsx",
+				"app/features/galaxy/galaxy-title.tsx",
+				"app/features/city/buildings.tsx",
+				"app/features/city/car-lights.tsx",
+				"app/features/city/city-scene.tsx",
+				"app/features/city/neon-signs.tsx",
+				"app/features/city/rain.tsx",
+				// Audio toggle uses browser APIs not available in full in Node
+				"app/features/audio/audio-toggle.tsx",
+				// Shared constants — trivially correct
+				"app/shared/theme.ts",
 			],
 			reporter: ["text", "lcov"],
 			thresholds: {


### PR DESCRIPTION
## Summary

This is the final PR in the Phase 3 stack. It wires all pods into the home route and configures the test environment for component tests.

### home.tsx changes

**3D path** (desktop ≥1024px + WebGL2 + no `prefers-reduced-motion`):
- `Experience` is `React.lazy()` imported — never executes on the server (SSR-safe)
- `useIs3DCapable()` hook: runs after hydration, checks viewport width, WebGL2 availability via `canvas.getContext('webgl2')`, and `prefers-reduced-motion` media query
- `useScrollSnap()`: dynamically imports GSAP + ScrollTrigger, attaches `ScrollTrigger.create()` snap instances at `SECTION_OFFSETS`; degrades gracefully if GSAP fails to load
- `scrollOffset` propagated from canvas via `onScrollChange` callback; `section = Math.round(offset * 2)` gates which overlays are visible (opacity + pointer-events)
- `AudioToggle` rendered only when `isSection3`

**Mobile / no-WebGL fallback**:
- CSS gradient background (`void → deep-navy → #050520`)
- All four overlay pods in normal document flow (`isMobile=true`)

**Accessibility**:
- `sr-only` div always present with `h1` name, project titles, email — machine-readable regardless of canvas support

### vitest.config.ts changes

- Document the `// @vitest-environment jsdom` per-file opt-in pattern
- Extend coverage exclude list to omit Three.js R3F components (WebGL unavailable in jsdom), `audio-toggle.tsx`, and `app/shared/theme.ts`

### Test result

All **99 tests passing** after integration.

## Part of

Phase 3 stacked PR chain:
1. `feat/phase-3-01-foundation` — Foundation ✓
2. `feat/phase-3-02-experience` — experience pod ✓
3. `feat/phase-3-03-galaxy` — galaxy pod ✓
4. `feat/phase-3-04-city` — city pod ✓
5. `feat/phase-3-05-overlays` — overlay pods ✓
6. `feat/phase-3-06-audio` — audio pod ✓
7. **→ This PR** — integration (merge last)